### PR TITLE
Consistent Handling of Cache Purge Tags

### DIFF
--- a/Plugin/PurgeCache.php
+++ b/Plugin/PurgeCache.php
@@ -32,6 +32,10 @@ class PurgeCache
             return $proceed($tags);
         }
 
+        if (is_string($tags)) {
+            $tags = [$tags];
+        }
+
         $this->cacheDebouncedEntries->add($tags);
         return true;
     }


### PR DESCRIPTION
I modified the aroundSendPurgeRequest method to convert the $tags parameter to an array if it is a string. This change ensures consistent handling of tags across the application.

The original sendPurgeRequest method also includes a similar check.