### PR TITLE
refactor: remove unused Config::getValue()

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -53,12 +53,4 @@ class Config
     {
         return (bool)$this->scopeConfig->isSetFlag($path, $scope, $scopeCode);
     }
-
-    /**
-     * Fetch a system config value
-     */
-    private function getValue(string $path, ?string $scope = 'default', ?string $scopeCode = null)
-    {
-        return $this->scopeConfig->getValue($path, $scope, $scopeCode);
-    }
 }


### PR DESCRIPTION
Removes `Config::getValue()`. Dead private method, nothing in the module calls it — only `getFlag()` is used (by `isModuleEnabled()`).

Spec: docs/specs/008-remove-dead-config-getvalue.md

No behavior change. Existing `ConfigTest` covers the remaining surface unchanged.