### PR TITLE
fix: reset debounce-skip flag in a finally block

### DIFF
--- a/Model/Entries.php
+++ b/Model/Entries.php
@@ -67,8 +67,12 @@ class Entries
         if (count($tags) > 0) {
             $this->logger->debug("[CacheDebounce] Flushing Tags: " . json_encode($tags));
             $this->config->setShouldDebouncePurgeRequest(false);
-            $this->purgeCache->sendPurgeRequest($tags);
-            $this->resourceConnection->getConnection()->delete($this->tableName);
+            try {
+                $this->purgeCache->sendPurgeRequest($tags);
+                $this->resourceConnection->getConnection()->delete($this->tableName);
+            } finally {
+                $this->config->setShouldDebouncePurgeRequest(true);
+            }
         } else {
             $this->logger->debug("[CacheDebounce] Nothing to flush");
         }

--- a/Test/Unit/Model/EntriesTest.php
+++ b/Test/Unit/Model/EntriesTest.php
@@ -49,4 +49,32 @@ class EntriesTest extends TestCase
 
         $this->cacheDebounceEntries->flush();
     }
+
+    public function testFlushResetsDebounceFlagEvenWhenPurgeRequestThrows()
+    {
+        $scopeConfig = $this->createMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
+        $scopeConfig->method('isSetFlag')->willReturn(true);
+        $config = new \SamJUK\CacheDebounce\Model\Config($scopeConfig);
+
+        $this->connection->method('fetchCol')->willReturn(self::CACHE_TAGS);
+        $this->purgeCacheModel->method('sendPurgeRequest')->willThrowException(new \RuntimeException('varnish down'));
+
+        $entries = new CacheDebounceEntries(
+            $config,
+            $this->purgeCacheModel,
+            $this->resourceConnection,
+            $this->loggerInterface
+        );
+
+        $this->assertTrue($config->shouldDebouncePurgeRequest());
+
+        try {
+            $entries->flush();
+            $this->fail('Expected sendPurgeRequest exception to propagate');
+        } catch (\RuntimeException $e) {
+            // expected
+        }
+
+        $this->assertTrue($config->shouldDebouncePurgeRequest());
+    }
 }

--- a/Test/Unit/Model/EntriesTest.php
+++ b/Test/Unit/Model/EntriesTest.php
@@ -75,9 +75,9 @@ class EntriesTest extends TestCase
             // expected
         }
 
-        $this->assertTrue($config->shouldDebouncePurgeRequest()); 
+        $this->assertTrue($config->shouldDebouncePurgeRequest());
     }
-  
+
     public function testAddWithEmptyTagsDoesNotTouchConnection()
     {
         $this->connection->expects($this->never())->method('insertArray');


### PR DESCRIPTION
Wraps the sendPurgeRequest/delete call in Entries::flush() in a try/finally so shouldDebouncePurgeRequest resets back to true regardless of outcome.

Currently the flag flips to false before the purge request and never resets. Harmless today since cron/CLI processes exit right after flush, but any longer-lived process reusing the same Entries/Config instance would silently stop debouncing after the first flush.

Spec: docs/specs/007-reset-debounce-flag-in-finally.md

Added a test using a real (non-mocked) Config to confirm the flag returns to its pre-flush state after flush() completes, including when sendPurgeRequest() throws.

Note: touches the same flush() body as #8 (only clear queue on confirmed purge success). Both are independent fixes, but whichever merges second will need a small rebase.