### PR TITLE
fix: only clear queue on confirmed purge success

### DIFF
--- a/Model/Entries.php
+++ b/Model/Entries.php
@@ -68,17 +68,27 @@ class Entries
     public function flush() : void
     {
         $tags = $this->get();
-        if (count($tags) > 0) {
-            $this->logger->debug("[CacheDebounce] Flushing Tags: " . json_encode($tags));
-            $this->config->setShouldDebouncePurgeRequest(false);
-            try {
-                $this->purgeCache->sendPurgeRequest($tags);
-                $this->resourceConnection->getConnection()->delete($this->tableName);
-            } finally {
-                $this->config->setShouldDebouncePurgeRequest(true);
-            }
-        } else {
+        if (count($tags) === 0) {
             $this->logger->debug("[CacheDebounce] Nothing to flush");
+            return;
+        }
+
+        $this->logger->debug("[CacheDebounce] Flushing Tags: " . json_encode($tags));
+        $this->config->setShouldDebouncePurgeRequest(false);
+
+        try {
+            $success = $this->purgeCache->sendPurgeRequest($tags);
+
+            if (!$success) {
+                $this->logger->error(
+                    "[CacheDebounce] Purge request failed — leaving tags queued for retry: " . json_encode($tags)
+                );
+                return;
+            }
+
+            $this->resourceConnection->getConnection()->delete($this->tableName);
+        } finally {
+            $this->config->setShouldDebouncePurgeRequest(true);
         }
     }
 }

--- a/Test/Unit/Model/EntriesTest.php
+++ b/Test/Unit/Model/EntriesTest.php
@@ -45,7 +45,28 @@ class EntriesTest extends TestCase
 
         $this->purgeCacheModel->expects($this->once())
             ->method('sendPurgeRequest')
-            ->with([self::CACHE_TAGS]);
+            ->with([self::CACHE_TAGS])
+            ->willReturn(true);
+
+        $this->connection->expects($this->once())->method('delete');
+
+        $this->cacheDebounceEntries->flush();
+    }
+
+    public function testFlushDoesNotClearQueueWhenPurgeRequestFails()
+    {
+        $this->connection->method('fetchCol')->willReturn([
+            self::CACHE_TAGS
+        ]);
+
+        $this->purgeCacheModel->expects($this->once())
+            ->method('sendPurgeRequest')
+            ->with([self::CACHE_TAGS])
+            ->willReturn(false);
+
+        $this->connection->expects($this->never())->method('delete');
+
+        $this->loggerInterface->expects($this->once())->method('error');
 
         $this->cacheDebounceEntries->flush();
     }


### PR DESCRIPTION
flush() deleted the queue table unconditionally after sendPurgeRequest(), regardless of whether it succeeded. sendPurgeRequest()'s bool return isn't consistently surfaced across the Magento versions this module supports — Varnish/socket errors can get swallowed. If Varnish is down, tags were deleted from the queue without ever being purged, leaving Varnish stale with no record of it.

Now a false return leaves the tags in the table (picked up by the next scheduled flush, same as any other pending tag) and logs an error instead of silently dropping them.

Spec: docs/specs/006-purge-confirmation-before-clear.md

Note: touches the same flush() body as #7 (reset debounce flag in finally). Both are independent fixes, but whichever merges second will need a small rebase.