### PR TITLE
fix: guard add() against an empty tags array

### DIFF
--- a/Model/Entries.php
+++ b/Model/Entries.php
@@ -44,6 +44,10 @@ class Entries
      */
     public function add(array $tags) : void
     {
+        if (!$tags) {
+            return;
+        }
+
         $this->resourceConnection->getConnection()
             ->insertArray($this->tableName, ['tag'], $tags);
     }

--- a/Test/Unit/Model/EntriesTest.php
+++ b/Test/Unit/Model/EntriesTest.php
@@ -49,4 +49,20 @@ class EntriesTest extends TestCase
 
         $this->cacheDebounceEntries->flush();
     }
+
+    public function testAddWithEmptyTagsDoesNotTouchConnection()
+    {
+        $this->connection->expects($this->never())->method('insertArray');
+
+        $this->cacheDebounceEntries->add([]);
+    }
+
+    public function testAddWithTagsInsertsThem()
+    {
+        $this->connection->expects($this->once())
+            ->method('insertArray')
+            ->with($this->anything(), ['tag'], self::CACHE_TAGS);
+
+        $this->cacheDebounceEntries->add(self::CACHE_TAGS);
+    }
 }


### PR DESCRIPTION
add() calls insertArray() directly on whatever tags array it's given. An empty array makes Zend_Db build an INSERT with no rows, which throws. add() is a public API and gets called with sendPurgeRequest()'s tags elsewhere in Magento core/other modules — an empty array is a valid, reachable input, not a caller bug.

Now add([]) is a no-op instead of a hard crash.

Spec: docs/specs/005-empty-tags-guard.md