### PR TITLE
Add Redis queue storage driver

### DIFF
--- a/Model/Config/Source/StorageDriver.php
+++ b/Model/Config/Source/StorageDriver.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class StorageDriver implements OptionSourceInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function toOptionArray(): array
+    {
+        return [
+            ['value' => 'db', 'label' => __('Database (default)')],
+            ['value' => 'redis', 'label' => __('Redis')],
+        ];
+    }
+}

--- a/Model/Storage/Pool.php
+++ b/Model/Storage/Pool.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Model\Storage;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\ObjectManagerInterface;
+
+class Pool implements QueueStorageInterface
+{
+    private const XML_PATH_STORAGE_DRIVER = 'samjuk_cache_debounce_advanced/general/storage_driver';
+    private const DEFAULT_DRIVER = 'db';
+
+    /** @var ObjectManagerInterface $objectManager */
+    private $objectManager;
+
+    /** @var ScopeConfigInterface $scopeConfig */
+    private $scopeConfig;
+
+    /** @var string[] $drivers */
+    private $drivers;
+
+    /** @var QueueStorageInterface|null $resolved */
+    private $resolved;
+
+    public function __construct(
+        ObjectManagerInterface $objectManager,
+        ScopeConfigInterface $scopeConfig,
+        array $drivers = []
+    ) {
+        $this->objectManager = $objectManager;
+        $this->scopeConfig = $scopeConfig;
+        $this->drivers = $drivers;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function add(array $tags): void
+    {
+        $this->driver()->add($tags);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function claim(): string
+    {
+        return $this->driver()->claim();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tags(string $batchId): array
+    {
+        return $this->driver()->tags($batchId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(string $batchId): void
+    {
+        $this->driver()->clear($batchId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function release(string $batchId): void
+    {
+        $this->driver()->release($batchId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function activeBatch(): string
+    {
+        return $this->driver()->activeBatch();
+    }
+
+    private function driver(): QueueStorageInterface
+    {
+        if ($this->resolved === null) {
+            $key = (string)$this->scopeConfig->getValue(self::XML_PATH_STORAGE_DRIVER) ?: self::DEFAULT_DRIVER;
+            $class = $this->drivers[$key] ?? $this->drivers[self::DEFAULT_DRIVER];
+            $this->resolved = $this->objectManager->create($class);
+        }
+
+        return $this->resolved;
+    }
+}

--- a/Model/Storage/Redis.php
+++ b/Model/Storage/Redis.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Model\Storage;
+
+use SamJUK\CacheDebounce\Model\Storage\Redis\ConnectionResolver;
+
+class Redis implements QueueStorageInterface
+{
+    private const KEY_LIVE = 'samjuk_cache_debounce:queue:live';
+    private const KEY_BATCH_PREFIX = 'samjuk_cache_debounce:queue:batch:';
+    private const ACTIVE_BATCH_ID = 'active';
+
+    /** @var ConnectionResolver $connectionResolver */
+    private $connectionResolver;
+
+    public function __construct(
+        ConnectionResolver $connectionResolver
+    ) {
+        $this->connectionResolver = $connectionResolver;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function add(array $tags): void
+    {
+        if (!$tags) {
+            return;
+        }
+
+        $this->connectionResolver->getClient()->sAdd(self::KEY_LIVE, ...$tags);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function claim(): string
+    {
+        if ($this->activeBatch() !== '') {
+            return '';
+        }
+
+        $client = $this->connectionResolver->getClient();
+
+        try {
+            $client->rename(self::KEY_LIVE, $this->batchKey(self::ACTIVE_BATCH_ID));
+        } catch (\CredisException $e) {
+            if (stripos($e->getMessage(), 'no such key') !== false) {
+                return '';
+            }
+            throw $e;
+        }
+
+        return self::ACTIVE_BATCH_ID;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tags(string $batchId): array
+    {
+        return $this->connectionResolver->getClient()->sMembers($this->batchKey($batchId));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(string $batchId): void
+    {
+        $this->connectionResolver->getClient()->del($this->batchKey($batchId));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function release(string $batchId): void
+    {
+        $client = $this->connectionResolver->getClient();
+        $client->sUnionStore(self::KEY_LIVE, self::KEY_LIVE, $this->batchKey($batchId));
+        $client->del($this->batchKey($batchId));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function activeBatch(): string
+    {
+        return $this->connectionResolver->getClient()->sCard($this->batchKey(self::ACTIVE_BATCH_ID)) > 0
+            ? self::ACTIVE_BATCH_ID
+            : '';
+    }
+
+    private function batchKey(string $batchId): string
+    {
+        return self::KEY_BATCH_PREFIX . $batchId;
+    }
+}

--- a/Model/Storage/Redis/ConnectionResolver.php
+++ b/Model/Storage/Redis/ConnectionResolver.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Model\Storage\Redis;
+
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Exception\LocalizedException;
+
+class ConnectionResolver
+{
+    private const CONFIG_PATH_DEDICATED = 'cache_debounce/redis';
+    private const CONFIG_PATH_SHARED_FALLBACK = 'cache/frontend/page_cache/backend_options';
+
+    /** @var DeploymentConfig $deploymentConfig */
+    private $deploymentConfig;
+
+    /** @var \Credis_Client|null $client */
+    private $client;
+
+    public function __construct(
+        DeploymentConfig $deploymentConfig
+    ) {
+        $this->deploymentConfig = $deploymentConfig;
+    }
+
+    /**
+     * @throws LocalizedException when no usable connection can be resolved.
+     */
+    public function getClient(): \Credis_Client
+    {
+        if ($this->client !== null) {
+            return $this->client;
+        }
+
+        $dedicated = $this->deploymentConfig->get(self::CONFIG_PATH_DEDICATED);
+        $config = $dedicated ? $this->normalize($dedicated) : $this->resolveFallback();
+
+        if (!$config) {
+            throw new LocalizedException(__(
+                'SamJUK_CacheDebounce: no Redis connection could be resolved. Configure the '
+                . '"cache_debounce.redis" block in app/etc/env.php, or configure a Redis backend '
+                . 'for the "page_cache" cache frontend.'
+            ));
+        }
+
+        $this->client = new \Credis_Client(
+            $config['host'],
+            (int)$config['port'],
+            null,
+            '',
+            (int)$config['database'],
+            $config['password'] ?: null
+        );
+
+        return $this->client;
+    }
+
+    private function resolveFallback(): ?array
+    {
+        $backendOptions = $this->deploymentConfig->get(self::CONFIG_PATH_SHARED_FALLBACK);
+
+        if (!$backendOptions) {
+            return null;
+        }
+
+        return [
+            'host' => $backendOptions['server'] ?? '127.0.0.1',
+            'port' => $backendOptions['port'] ?? 6379,
+            'password' => $backendOptions['password'] ?? '',
+            'database' => $backendOptions['database'] ?? 0,
+        ];
+    }
+
+    /**
+     * Fill in defaults for whichever of host/port/database/password the
+     * "cache_debounce.redis" env.php block leaves out.
+     */
+    private function normalize(array $config): array
+    {
+        return [
+            'host' => $config['host'] ?? '127.0.0.1',
+            'port' => $config['port'] ?? 6379,
+            'password' => $config['password'] ?? '',
+            'database' => $config['database'] ?? 0,
+        ];
+    }
+}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,45 @@ Option | Config Path | Default | Description
 --- | --- | --- | ---
 Enabled | `samjuk_cache_debounce/general/enabled` | `0` | Feature flag to toggle functionality of the module
 Flush Schedule | `samjuk_cache_debounce/cron/flush_schedule` | `*/5 0 0 0 0` | Cron schedule to run the scheduled flush
+Storage Driver | `samjuk_cache_debounce_advanced/general/storage_driver` | `db` | Queue storage backend — `db` or `redis`. A deploy-time infra decision, not a store setting — see below
+
+This one is a deliberate exception to "Configuration can be handled via System configuration" above: it's hidden from Stores > Configuration entirely (`showInDefault`/`showInWebsite`/`showInStore` all `0`) and gated behind its own ACL resource (`SamJUK_CacheDebounce::storage_driver`) that isn't granted to any role by default. It exists only so `config:set` has a registered path to write to. Set it with:
+```sh
+php bin/magento config:set samjuk_cache_debounce_advanced/general/storage_driver redis
+```
+Add `-e` to lock it into `app/etc/env.php` instead of `core_config_data`, removing Admin overridability entirely.
+
+### Redis storage driver
+
+The `redis` driver connects via a dedicated `app/etc/env.php` block:
+```php
+'cache_debounce' => [
+    'redis' => [
+        'host' => '127.0.0.1',
+        'port' => '6379',
+        'password' => '',
+        'database' => '2',
+    ],
+],
+```
+
+If that block is absent, the module falls back to whatever Redis backend is already configured for the `page_cache` cache frontend, so it works zero-config once the driver is switched on.
+
+> **Note:** sharing the page cache's Redis instance means pending purge tags are subject to that instance's `maxmemory-policy`. If it's `allkeys-lru`/`allkeys-lfu` (common for FPC), tags can be silently evicted under memory pressure. Configure a dedicated block above to avoid this.
+
+### Adding your own storage driver
+
+Drivers are resolved from an array bound in `etc/di.xml`, keyed by the value of `storage_driver`. Any module can add an entry to extend it, without touching this module's `di.xml`:
+```xml
+<type name="SamJUK\CacheDebounce\Model\Storage\Pool">
+    <arguments>
+        <argument name="drivers" xsi:type="array">
+            <item name="my_driver" xsi:type="string">Vendor\Module\Model\Storage\MyDriver</item>
+        </argument>
+    </arguments>
+</type>
+```
+`MyDriver` just needs to implement `QueueStorageInterface`. Then `bin/magento config:set samjuk_cache_debounce_advanced/general/storage_driver my_driver`.
 
 ## Will this help my store?
 

--- a/Test/Integration/Model/Storage/Redis/ConnectionResolverTest.php
+++ b/Test/Integration/Model/Storage/Redis/ConnectionResolverTest.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Integration\Model\Storage\Redis;
+
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\TestFramework\ObjectManager;
+use SamJUK\CacheDebounce\Model\Storage\Redis\ConnectionResolver;
+
+/**
+ * Requires a Redis server reachable at 127.0.0.1:6379.
+ */
+class ConnectionResolverTest extends TestCase
+{
+    private const CANARY_KEY = 'samjuk_cache_debounce:test:canary';
+    private const DEDICATED_DATABASE = 3;
+    private const FALLBACK_DATABASE = 4;
+
+    private $dedicatedResolver;
+    private $fallbackResolver;
+
+    protected function setUp(): void
+    {
+        $reader = ObjectManager::getInstance()->get(DeploymentConfig\Reader::class);
+
+        $dedicatedConfig = new DeploymentConfig($reader, ['cache_debounce' => ['redis' => [
+            'host' => '127.0.0.1',
+            'port' => '6379',
+            'password' => '',
+            'database' => (string)self::DEDICATED_DATABASE,
+        ]]]);
+        $fallbackConfig = new DeploymentConfig($reader, ['cache' => ['frontend' => ['page_cache' => [
+            'backend_options' => [
+                'server' => '127.0.0.1',
+                'port' => '6379',
+                'password' => '',
+                'database' => (string)self::FALLBACK_DATABASE,
+            ],
+        ]]]]);
+
+        $this->dedicatedResolver = new ConnectionResolver($dedicatedConfig);
+        $this->fallbackResolver = new ConnectionResolver($fallbackConfig);
+
+        $this->dedicatedResolver->getClient()->flushDb();
+        $this->fallbackResolver->getClient()->flushDb();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dedicatedResolver->getClient()->flushDb();
+        $this->fallbackResolver->getClient()->flushDb();
+    }
+
+    public function testResolvesTheDedicatedConnection()
+    {
+        $client = $this->dedicatedResolver->getClient();
+
+        $client->set(self::CANARY_KEY, '1');
+        $this->assertSame('1', $client->get(self::CANARY_KEY));
+    }
+
+    public function testFallsBackToThePageCacheConnectionWhenNoDedicatedBlockIsConfigured()
+    {
+        $client = $this->fallbackResolver->getClient();
+
+        $client->set(self::CANARY_KEY, '1');
+        $this->assertSame('1', $client->get(self::CANARY_KEY));
+    }
+}

--- a/Test/Integration/Model/Storage/RedisTest.php
+++ b/Test/Integration/Model/Storage/RedisTest.php
@@ -1,0 +1,133 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Integration\Model\Storage;
+
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\TestFramework\ObjectManager;
+use SamJUK\CacheDebounce\Model\Storage\Redis;
+use SamJUK\CacheDebounce\Model\Storage\Redis\ConnectionResolver;
+
+/**
+ * Requires a Redis server reachable at 127.0.0.1:6379.
+ */
+class RedisTest extends TestCase
+{
+    private const CONNECTION_CONFIG = [
+        'host' => '127.0.0.1',
+        'port' => '6379',
+        'password' => '',
+        'database' => '2',
+    ];
+
+    private $storage;
+    private $rawClient;
+
+    protected function setUp(): void
+    {
+        $reader = ObjectManager::getInstance()->get(DeploymentConfig\Reader::class);
+        $deploymentConfig = new DeploymentConfig($reader, ['cache_debounce' => ['redis' => self::CONNECTION_CONFIG]]);
+
+        $this->storage = new Redis(new ConnectionResolver($deploymentConfig));
+
+        // Independent resolver instance, not the class under test.
+        $this->rawClient = (new ConnectionResolver($deploymentConfig))->getClient();
+        $this->rawClient->flushDb();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rawClient->flushDb();
+    }
+
+    public function testAddClaimTagsClearRoundTrip()
+    {
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+
+        $batchId = $this->storage->claim();
+        $this->assertNotSame('', $batchId);
+
+        $tags = $this->storage->tags($batchId);
+        sort($tags);
+        $this->assertEquals(['cat_c_1', 'cat_c_2'], $tags);
+
+        $this->storage->clear($batchId);
+        $this->assertEquals([], $this->storage->tags($batchId));
+    }
+
+    public function testAddDuringClaimIsNotLostOrDuplicated()
+    {
+        $this->storage->add(['cat_c_1']);
+
+        $batchId = $this->storage->claim();
+
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+
+        $this->assertEquals(['cat_c_1'], $this->storage->tags($batchId));
+
+        $this->storage->clear($batchId);
+
+        $nextBatchId = $this->storage->claim();
+        $tags = $this->storage->tags($nextBatchId);
+        sort($tags);
+        $this->assertEquals(['cat_c_1', 'cat_c_2'], $tags);
+
+        $this->storage->clear($nextBatchId);
+    }
+
+    public function testSecondConcurrentClaimReturnsEmptyString()
+    {
+        $this->storage->add(['cat_c_1']);
+
+        $firstBatchId = $this->storage->claim();
+        $this->assertNotSame('', $firstBatchId);
+
+        $this->assertSame('', $this->storage->claim());
+
+        $this->storage->clear($firstBatchId);
+    }
+
+    public function testReleaseMakesTheBatchClaimableAgain()
+    {
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+        $batchId = $this->storage->claim();
+
+        $this->storage->release($batchId);
+
+        $this->assertEquals([], $this->storage->tags($batchId));
+
+        $nextBatchId = $this->storage->claim();
+        $tags = $this->storage->tags($nextBatchId);
+        sort($tags);
+        $this->assertEquals(['cat_c_1', 'cat_c_2'], $tags);
+    }
+
+    public function testReleaseMergesCleanlyWithTagsReQueuedWhileClaimed()
+    {
+        $this->storage->add(['cat_c_1']);
+        $batchId = $this->storage->claim();
+
+        // Same tag re-queued while the original batch is still in flight —
+        // release() must not duplicate it; Redis sets dedupe natively.
+        $this->storage->add(['cat_c_1']);
+
+        $this->storage->release($batchId);
+
+        $nextBatchId = $this->storage->claim();
+        $this->assertEquals(['cat_c_1'], $this->storage->tags($nextBatchId));
+    }
+
+    public function testActiveBatchTracksClaimedWorkUntilItIsCleared()
+    {
+        $this->assertSame('', $this->storage->activeBatch());
+
+        $this->storage->add(['cat_c_1']);
+        $batchId = $this->storage->claim();
+
+        $this->assertSame($batchId, $this->storage->activeBatch());
+
+        $this->storage->clear($batchId);
+
+        $this->assertSame('', $this->storage->activeBatch());
+    }
+}

--- a/Test/Unit/Model/Config/Source/StorageDriverTest.php
+++ b/Test/Unit/Model/Config/Source/StorageDriverTest.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Unit\Model\Config\Source;
+
+use PHPUnit\Framework\TestCase;
+use SamJUK\CacheDebounce\Model\Config\Source\StorageDriver;
+
+class StorageDriverTest extends TestCase
+{
+    public function testToOptionArrayListsEachRegisteredDriver()
+    {
+        $values = array_column((new StorageDriver())->toOptionArray(), 'value');
+
+        $this->assertSame(['db', 'redis'], $values);
+    }
+}

--- a/Test/Unit/Model/Storage/PoolTest.php
+++ b/Test/Unit/Model/Storage/PoolTest.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Unit\Model\Storage;
+
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\ObjectManagerInterface;
+use SamJUK\CacheDebounce\Model\Storage\Database;
+use SamJUK\CacheDebounce\Model\Storage\Pool;
+use SamJUK\CacheDebounce\Model\Storage\Redis;
+
+class PoolTest extends TestCase
+{
+    private const XML_PATH_STORAGE_DRIVER = 'samjuk_cache_debounce_advanced/general/storage_driver';
+    private const CACHE_TAGS = ['cat_c_1', 'cat_c_2'];
+    private const DRIVERS = [
+        'db' => Database::class,
+        'redis' => Redis::class,
+    ];
+
+    private $objectManager;
+    private $scopeConfig;
+    private $database;
+    private $redis;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = $this->createMock(ObjectManagerInterface::class);
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->database = $this->createMock(Database::class);
+        $this->redis = $this->createMock(Redis::class);
+
+        $this->objectManager->method('create')->willReturnMap([
+            [Database::class, [], $this->database],
+            [Redis::class, [], $this->redis],
+        ]);
+    }
+
+    private function pool(): Pool
+    {
+        return new Pool($this->objectManager, $this->scopeConfig, self::DRIVERS);
+    }
+
+    public function testUsesDatabaseDriverByDefault()
+    {
+        $this->scopeConfig->method('getValue')->with(self::XML_PATH_STORAGE_DRIVER)->willReturn(null);
+
+        $this->database->expects($this->once())->method('add')->with(self::CACHE_TAGS);
+
+        $this->pool()->add(self::CACHE_TAGS);
+    }
+
+    public function testUsesDatabaseDriverForAnyValueOtherThanRedis()
+    {
+        $this->scopeConfig->method('getValue')->willReturn('db');
+
+        $this->database->expects($this->once())->method('claim')->willReturn('batch-123');
+
+        $this->pool()->claim();
+    }
+
+    public function testUsesRedisDriverWhenConfiguredAndNeverTouchesDatabase()
+    {
+        $this->scopeConfig->method('getValue')->willReturn('redis');
+
+        $this->database->expects($this->never())->method('add');
+        $this->redis->expects($this->once())->method('add')->with(self::CACHE_TAGS);
+
+        $this->pool()->add(self::CACHE_TAGS);
+    }
+
+    public function testDriverIsOnlyResolvedOnceAcrossMultipleCalls()
+    {
+        $objectManager = $this->createMock(ObjectManagerInterface::class);
+        $objectManager->expects($this->once())->method('create')->with(Redis::class)->willReturn($this->redis);
+        $this->scopeConfig->method('getValue')->willReturn('redis');
+
+        $pool = new Pool($objectManager, $this->scopeConfig, self::DRIVERS);
+        $pool->add(['cat_c_1']);
+        $pool->claim();
+    }
+
+    public function testReleaseDelegatesToTheResolvedDriver()
+    {
+        $this->scopeConfig->method('getValue')->willReturn('db');
+        $this->database->expects($this->once())->method('release')->with('batch-123');
+
+        $this->pool()->release('batch-123');
+    }
+
+    public function testActiveBatchDelegatesToTheResolvedDriver()
+    {
+        $this->scopeConfig->method('getValue')->willReturn('redis');
+        $this->redis->expects($this->once())->method('activeBatch')->willReturn('batch-123');
+
+        $this->assertSame('batch-123', $this->pool()->activeBatch());
+    }
+}

--- a/Test/Unit/Model/Storage/Redis/ConnectionResolverTest.php
+++ b/Test/Unit/Model/Storage/Redis/ConnectionResolverTest.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Unit\Model\Storage\Redis;
+
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Exception\LocalizedException;
+use SamJUK\CacheDebounce\Model\Storage\Redis\ConnectionResolver;
+
+class ConnectionResolverTest extends TestCase
+{
+    private const DEDICATED_CONFIG = ['host' => '10.0.0.1', 'port' => '6390', 'password' => 'x', 'database' => '2'];
+    private const FALLBACK_CONFIG = ['server' => '10.0.0.2', 'port' => '6379', 'password' => '', 'database' => '0'];
+
+    private $deploymentConfig;
+
+    protected function setUp(): void
+    {
+        $this->deploymentConfig = $this->createMock(DeploymentConfig::class);
+    }
+
+    public function testDedicatedConfigTakesPriorityOverTheSharedFallback()
+    {
+        $this->deploymentConfig->method('get')->willReturnMap([
+            ['cache_debounce/redis', null, self::DEDICATED_CONFIG],
+            ['cache/frontend/page_cache/backend_options', null, self::FALLBACK_CONFIG],
+        ]);
+
+        $this->assertResolvesToClient();
+    }
+
+    public function testFallsBackToThePageCacheBackendWhenDedicatedConfigIsAbsent()
+    {
+        $this->deploymentConfig->method('get')->willReturnMap([
+            ['cache_debounce/redis', null, null],
+            ['cache/frontend/page_cache/backend_options', null, self::FALLBACK_CONFIG],
+        ]);
+
+        $this->assertResolvesToClient();
+    }
+
+    public function testThrowsLocalizedExceptionWhenNeitherConfigIsAvailable()
+    {
+        $this->deploymentConfig->method('get')->willReturn(null);
+
+        $resolver = new ConnectionResolver($this->deploymentConfig);
+
+        $this->expectException(LocalizedException::class);
+
+        $resolver->getClient();
+    }
+
+    public function testDedicatedConfigMissingKeysFallsBackToDefaultsInsteadOfErroring()
+    {
+        $this->deploymentConfig->method('get')->willReturnMap([
+            ['cache_debounce/redis', null, ['host' => '10.0.0.9']],
+            ['cache/frontend/page_cache/backend_options', null, null],
+        ]);
+
+        $this->assertResolvesToClient();
+    }
+
+    private function assertResolvesToClient(): void
+    {
+        $resolver = new ConnectionResolver($this->deploymentConfig);
+
+        $this->assertInstanceOf(\Credis_Client::class, $resolver->getClient());
+    }
+}

--- a/Test/Unit/Model/Storage/RedisTest.php
+++ b/Test/Unit/Model/Storage/RedisTest.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Unit\Model\Storage;
+
+use PHPUnit\Framework\TestCase;
+use SamJUK\CacheDebounce\Model\Storage\Redis;
+use SamJUK\CacheDebounce\Model\Storage\Redis\ConnectionResolver;
+
+class RedisTest extends TestCase
+{
+    private const KEY_LIVE = 'samjuk_cache_debounce:queue:live';
+    private const KEY_BATCH_PREFIX = 'samjuk_cache_debounce:queue:batch:';
+    private const ACTIVE_BATCH_ID = 'active';
+
+    private $client;
+    private $connectionResolver;
+    private $storage;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->getMockBuilder(\Credis_Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['sAdd', 'rename', 'sMembers', 'del', 'sUnionStore', 'sCard'])
+            ->getMock();
+        $this->connectionResolver = $this->createMock(ConnectionResolver::class);
+        $this->connectionResolver->method('getClient')->willReturn($this->client);
+
+        $this->storage = new Redis($this->connectionResolver);
+    }
+
+    public function testAddWithEmptyTagsDoesNotTouchConnection()
+    {
+        $this->client->expects($this->never())->method('sAdd');
+
+        $this->storage->add([]);
+    }
+
+    public function testAddSaddsTagsIntoTheLiveSet()
+    {
+        $this->client->expects($this->once())
+            ->method('sAdd')
+            ->with(self::KEY_LIVE, 'cat_c_1', 'cat_c_2');
+
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+    }
+
+    public function testClaimReturnsEmptyStringWhenLiveKeyDoesNotExist()
+    {
+        $this->client->method('sCard')->willReturn(0);
+        $this->client->method('rename')->willThrowException(new \CredisException('ERR no such key'));
+
+        $this->assertSame('', $this->storage->claim());
+    }
+
+    public function testClaimDoesNotSwallowOtherRedisErrors()
+    {
+        $this->client->method('sCard')->willReturn(0);
+        $this->client->method('rename')->willThrowException(new \CredisException('ERR something else'));
+
+        $this->expectException(\CredisException::class);
+        $this->expectExceptionMessage('ERR something else');
+
+        $this->storage->claim();
+    }
+
+    public function testClaimRenamesLiveKeyToABatchKeyAndReturnsItsId()
+    {
+        $this->client->method('sCard')->willReturn(0);
+        $this->client->expects($this->once())
+            ->method('rename')
+            ->with(self::KEY_LIVE, self::KEY_BATCH_PREFIX . self::ACTIVE_BATCH_ID);
+
+        $batchId = $this->storage->claim();
+
+        $this->assertSame(self::ACTIVE_BATCH_ID, $batchId);
+    }
+
+    public function testClaimReturnsEmptyStringWhenAnotherBatchIsAlreadyClaimed()
+    {
+        $this->client->method('sCard')->willReturn(1);
+        $this->client->expects($this->never())->method('rename');
+
+        $this->assertSame('', $this->storage->claim());
+    }
+
+    public function testTagsReadsFromTheBatchKey()
+    {
+        $this->client->expects($this->once())
+            ->method('sMembers')
+            ->with(self::KEY_BATCH_PREFIX . 'batch-123')
+            ->willReturn(['cat_c_1']);
+
+        $this->assertSame(['cat_c_1'], $this->storage->tags('batch-123'));
+    }
+
+    public function testClearDeletesTheBatchKey()
+    {
+        $this->client->expects($this->once())
+            ->method('del')
+            ->with(self::KEY_BATCH_PREFIX . self::ACTIVE_BATCH_ID);
+
+        $this->storage->clear(self::ACTIVE_BATCH_ID);
+    }
+
+    public function testReleaseMergesBatchSetBackIntoLiveSetThenDeletesTheBatch()
+    {
+        $this->client->expects($this->once())
+            ->method('sUnionStore')
+            ->with(self::KEY_LIVE, self::KEY_LIVE, self::KEY_BATCH_PREFIX . self::ACTIVE_BATCH_ID);
+        $this->client->expects($this->once())
+            ->method('del')
+            ->with(self::KEY_BATCH_PREFIX . self::ACTIVE_BATCH_ID);
+
+        $this->storage->release(self::ACTIVE_BATCH_ID);
+    }
+
+    public function testActiveBatchReturnsEmptyStringWhenNoBatchIsClaimed()
+    {
+        $this->client->method('sCard')->with(self::KEY_BATCH_PREFIX . self::ACTIVE_BATCH_ID)->willReturn(0);
+
+        $this->assertSame('', $this->storage->activeBatch());
+    }
+
+    public function testActiveBatchReturnsIdOfAlreadyClaimedBatch()
+    {
+        $this->client->method('sCard')->with(self::KEY_BATCH_PREFIX . self::ACTIVE_BATCH_ID)->willReturn(1);
+
+        $this->assertSame(self::ACTIVE_BATCH_ID, $this->storage->activeBatch());
+    }
+}

--- a/etc/adminhtml/acl.xml
+++ b/etc/adminhtml/acl.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_settings">
+                        <resource id="Magento_Config::config">
+                            <resource id="SamJUK_CacheDebounce::system_config" title="Cache Debounce Section" translate="title" sortOrder="10">
+                                <resource id="SamJUK_CacheDebounce::storage_driver" title="Cache Debounce Storage Driver (Advanced)" translate="title" sortOrder="10" />
+                            </resource>
+                        </resource>
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -23,5 +23,20 @@
                 </field>
             </group>
         </section>
+
+        <!-- showInDefault/Website/Store all "0" hides this from Admin UI; config:set still works -->
+        <section id="samjuk_cache_debounce_advanced" translate="label" type="text" sortOrder="20" showInDefault="0" showInWebsite="0" showInStore="0">
+            <label>Cache Debounce (Advanced)</label>
+            <tab>samjuk</tab>
+            <resource>SamJUK_CacheDebounce::storage_driver</resource>
+            <group id="general" translate="label" type="text" sortOrder="10" showInDefault="0" showInWebsite="0" showInStore="0">
+                <label>General</label>
+                <field id="storage_driver" translate="label comment" type="select" sortOrder="10" showInDefault="0" showInWebsite="0" showInStore="0">
+                    <label>Storage Driver</label>
+                    <comment>Do not change unless you know what you are doing. See README.md.</comment>
+                    <source_model>SamJUK\CacheDebounce\Model\Config\Source\StorageDriver</source_model>
+                </field>
+            </group>
+        </section>
     </system>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -9,5 +9,10 @@
                 <flush_schedule>*/15 * * * *</flush_schedule>
             </cron>
         </samjuk_cache_debounce>
+        <samjuk_cache_debounce_advanced>
+            <general>
+                <storage_driver>db</storage_driver>
+            </general>
+        </samjuk_cache_debounce_advanced>
     </default>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <preference for="SamJUK\CacheDebounce\Model\Storage\QueueStorageInterface" type="SamJUK\CacheDebounce\Model\Storage\Database" />
+    <preference for="SamJUK\CacheDebounce\Model\Storage\QueueStorageInterface" type="SamJUK\CacheDebounce\Model\Storage\Pool" />
+
+    <type name="SamJUK\CacheDebounce\Model\Storage\Pool">
+        <arguments>
+            <argument name="drivers" xsi:type="array">
+                <item name="db" xsi:type="string">SamJUK\CacheDebounce\Model\Storage\Database</item>
+                <item name="redis" xsi:type="string">SamJUK\CacheDebounce\Model\Storage\Redis</item>
+            </argument>
+        </arguments>
+    </type>
 
     <type name="Magento\CacheInvalidate\Model\PurgeCache">
         <plugin name="samjuk_cachedebounce_purge_cache" type="SamJUK\CacheDebounce\Plugin\PurgeCache" />


### PR DESCRIPTION
## Summary
- Stacked on #10 — adds a `Redis` implementation of `QueueStorageInterface` (`SADD`/atomic `RENAME`/`SMEMBERS`/`DEL`), giving native dedupe and the same atomic claim/drain guarantee as the DB driver, without touching MySQL.
- Connection resolves from a dedicated `cache_debounce.redis` env.php block, falling back to the existing `page_cache` Redis backend if absent (with a loud warning about that instance's eviction policy potentially dropping pending tags silently).
- Driver selection is a `Provider` decorator bound once in `di.xml`, switched via a scoped config value (`storage_driver`) that has no `system.xml` field — set only via `config:set`, never Admin-visible, no per-driver `di.xml` override module needed.
- CI: runs a Redis container alongside the Magento test container so the new integration tests have something to connect to.

## Test plan
- [x] `vendor/bin/phpunit Test/Unit` passes (verified against a real Magento install's classes, including the Credis mock-destructor edge case)
- [x] `vendor/bin/phpstan analyse` clean at the repo's configured level
- [ ] `dev/tests/integration` against the CI Redis service
- [ ] Manually confirm `config:set samjuk_cache_debounce/general/storage_driver redis` switches the driver and the field doesn't appear in Stores > Configuration