### PR TITLE
Add staggered/batched purge release (spec 003)

### DIFF
--- a/Console/Command/Flush.php
+++ b/Console/Command/Flush.php
@@ -8,21 +8,21 @@ use Magento\Framework\Exception\LocalizedException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use SamJUK\CacheDebounce\Model\Entries as CacheDebouncedEntries;
+use SamJUK\CacheDebounce\Model\StaggeredFlush;
 
 class Flush extends Command
 {
-    private $cacheDebouncedEntries;
+    private $staggeredFlush;
 
     /**
-     * @param CacheDebouncedEntries $cacheDebouncedEntries
+     * @param StaggeredFlush $staggeredFlush
      * @param string|null $name
      */
     public function __construct(
-        CacheDebouncedEntries $cacheDebouncedEntries,
+        StaggeredFlush $staggeredFlush,
         $name = null
     ) {
-        $this->cacheDebouncedEntries = $cacheDebouncedEntries;
+        $this->staggeredFlush = $staggeredFlush;
         parent::__construct($name);
     }
 
@@ -37,7 +37,7 @@ class Flush extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
-            $this->cacheDebouncedEntries->flush();
+            $this->staggeredFlush->execute();
             $output->writeln('<info>Flushed Debounced Cache Purges.</info>');
             return 0;
         } catch (LocalizedException $e) {

--- a/Console/Command/Status.php
+++ b/Console/Command/Status.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Console\Command;
+
+use Magento\Framework\FlagManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use SamJUK\CacheDebounce\Model\Config;
+use SamJUK\CacheDebounce\Model\Entries;
+use SamJUK\CacheDebounce\Model\LagDetector;
+use SamJUK\CacheDebounce\Model\Storage\QueueStorageInterface;
+
+class Status extends Command
+{
+    private $storage;
+    private $config;
+    private $flagManager;
+
+    /**
+     * @param QueueStorageInterface $storage
+     * @param Config $config
+     * @param FlagManager $flagManager
+     * @param string|null $name
+     */
+    public function __construct(
+        QueueStorageInterface $storage,
+        Config $config,
+        FlagManager $flagManager,
+        $name = null
+    ) {
+        $this->storage = $storage;
+        $this->config = $config;
+        $this->flagManager = $flagManager;
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('samjuk:cache-debounce:status');
+        $this->setDescription('Shows the current state of the debounced purge queue.');
+
+        parent::configure();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $pending = $this->storage->pendingCount();
+        $oldestAgeSeconds = $this->storage->oldestPendingAgeSeconds();
+        $activeBatch = $this->storage->activeBatch();
+        $activeBatchTagCount = $activeBatch !== '' ? count($this->storage->tags($activeBatch)) : 0;
+
+        $lastFlushAt = $this->flagManager->getFlagData(Entries::FLAG_LAST_FLUSH_AT);
+        $lastFlushDuration = $this->flagManager->getFlagData(Entries::FLAG_LAST_FLUSH_DURATION);
+        $consecutiveLaggingRuns = (int)$this->flagManager->getFlagData(LagDetector::FLAG_CONSECUTIVE_LAGGING_RUNS);
+
+        $oldestAgeLabel = $oldestAgeSeconds !== null
+            ? sprintf(' (oldest queued %s ago)', $this->formatDuration($oldestAgeSeconds))
+            : '';
+
+        $output->writeln(sprintf('Pending tags:             %d%s', $pending, $oldestAgeLabel));
+
+        $output->writeln(sprintf(
+            'Active batch:             %s',
+            $activeBatch === '' ? 'none' : sprintf('%s (%d tags)', $activeBatch, $activeBatchTagCount)
+        ));
+
+        $output->writeln(sprintf(
+            'Last flush:               %s',
+            $lastFlushAt ? sprintf('%s (duration %.1fs)', $lastFlushAt, (float)$lastFlushDuration) : 'never'
+        ));
+
+        $output->writeln(sprintf(
+            'Consecutive lagging runs: %d / %d',
+            $consecutiveLaggingRuns,
+            $this->config->getStaggerLagAlertAfterRuns()
+        ));
+
+        return 0;
+    }
+
+    private function formatDuration(int $seconds): string
+    {
+        if ($seconds < 60) {
+            return $seconds . 's';
+        }
+
+        return sprintf('%dm%02ds', intdiv($seconds, 60), $seconds % 60);
+    }
+}

--- a/Cron/Flush.php
+++ b/Cron/Flush.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 
 namespace SamJUK\CacheDebounce\Cron;
 
-use SamJUK\CacheDebounce\Model\Entries as CacheDebouncedEntries;
+use SamJUK\CacheDebounce\Model\StaggeredFlush;
 
 class Flush
 {
-    /** @var CacheDebouncedEntries $cacheDebouncedEntries */
-    private $cacheDebouncedEntries;
+    /** @var StaggeredFlush $staggeredFlush */
+    private $staggeredFlush;
 
     public function __construct(
-        CacheDebouncedEntries $cacheDebouncedEntries
+        StaggeredFlush $staggeredFlush
     ) {
-        $this->cacheDebouncedEntries = $cacheDebouncedEntries;
+        $this->staggeredFlush = $staggeredFlush;
     }
 
     public function execute() : void
     {
-        $this->cacheDebouncedEntries->flush();
+        $this->staggeredFlush->execute();
     }
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -9,6 +9,12 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 class Config
 {
     private const XML_PATH_GENERAL_ENABLED = 'samjuk_cache_debounce/general/enabled';
+    private const XML_PATH_STAGGER_ENABLED = 'samjuk_cache_debounce/stagger/enabled';
+    private const XML_PATH_STAGGER_BATCH_SIZE = 'samjuk_cache_debounce/stagger/batch_size';
+    private const XML_PATH_STAGGER_INTERVAL_MS = 'samjuk_cache_debounce/stagger/interval_ms';
+    private const XML_PATH_STAGGER_MAX_RUNTIME_SECONDS = 'samjuk_cache_debounce/stagger/max_runtime_seconds';
+    private const XML_PATH_STAGGER_LAG_RATIO_THRESHOLD = 'samjuk_cache_debounce/stagger/lag_ratio_threshold';
+    private const XML_PATH_STAGGER_LAG_ALERT_AFTER_RUNS = 'samjuk_cache_debounce/stagger/lag_alert_after_runs';
 
     /** @var bool $shouldDebouncePurgeRequest */
     private $shouldDebouncePurgeRequest = true;
@@ -44,6 +50,54 @@ class Config
     public function setShouldDebouncePurgeRequest(bool $state) : void
     {
         $this->shouldDebouncePurgeRequest = $state;
+    }
+
+    /**
+     * Check if staggered/batched purge release is enabled
+     */
+    public function isStaggerEnabled() : bool
+    {
+        return $this->getFlag(self::XML_PATH_STAGGER_ENABLED);
+    }
+
+    /**
+     * Tags per staggered purge chunk
+     */
+    public function getStaggerBatchSize() : int
+    {
+        return (int)$this->scopeConfig->getValue(self::XML_PATH_STAGGER_BATCH_SIZE);
+    }
+
+    /**
+     * Pause, in milliseconds, between staggered purge chunks
+     */
+    public function getStaggerIntervalMs() : int
+    {
+        return (int)$this->scopeConfig->getValue(self::XML_PATH_STAGGER_INTERVAL_MS);
+    }
+
+    /**
+     * Safety budget, in seconds, per staggered release invocation
+     */
+    public function getStaggerMaxRuntimeSeconds() : int
+    {
+        return (int)$this->scopeConfig->getValue(self::XML_PATH_STAGGER_MAX_RUNTIME_SECONDS);
+    }
+
+    /**
+     * Ratio of arrived-during-drain to just-drained tags that counts as lagging
+     */
+    public function getStaggerLagRatioThreshold() : float
+    {
+        return (float)$this->scopeConfig->getValue(self::XML_PATH_STAGGER_LAG_RATIO_THRESHOLD);
+    }
+
+    /**
+     * Consecutive lagging runs before an admin notification is raised
+     */
+    public function getStaggerLagAlertAfterRuns() : int
+    {
+        return (int)$this->scopeConfig->getValue(self::XML_PATH_STAGGER_LAG_ALERT_AFTER_RUNS);
     }
 
     /**

--- a/Model/Config/Source/StorageDriver.php
+++ b/Model/Config/Source/StorageDriver.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class StorageDriver implements OptionSourceInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function toOptionArray(): array
+    {
+        return [
+            ['value' => 'db', 'label' => __('Database (default)')],
+            ['value' => 'redis', 'label' => __('Redis')],
+        ];
+    }
+}

--- a/Model/Entries.php
+++ b/Model/Entries.php
@@ -7,10 +7,14 @@ namespace SamJUK\CacheDebounce\Model;
 use SamJUK\CacheDebounce\Model\Config;
 use SamJUK\CacheDebounce\Model\Storage\QueueStorageInterface;
 use Magento\CacheInvalidate\Model\PurgeCache;
+use Magento\Framework\FlagManager;
 use Psr\Log\LoggerInterface;
 
 class Entries
 {
+    public const FLAG_LAST_FLUSH_AT = 'samjuk_cache_debounce_last_flush_at';
+    public const FLAG_LAST_FLUSH_DURATION = 'samjuk_cache_debounce_last_flush_duration';
+
     /** @var QueueStorageInterface $storage */
     private $storage;
 
@@ -23,16 +27,21 @@ class Entries
     /** @var LoggerInterface $logger */
     private $logger;
 
+    /** @var FlagManager $flagManager */
+    private $flagManager;
+
     public function __construct(
         Config $config,
         PurgeCache $purgeCache,
         QueueStorageInterface $storage,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        FlagManager $flagManager
     ) {
         $this->config = $config;
         $this->purgeCache = $purgeCache;
         $this->storage = $storage;
         $this->logger = $logger;
+        $this->flagManager = $flagManager;
     }
 
     /**
@@ -48,7 +57,11 @@ class Entries
      */
     public function flush() : void
     {
-        $batchId = $this->storage->claim();
+        // Resume an already-claimed batch before claiming new work.
+        $batchId = $this->storage->activeBatch();
+        if ($batchId === '') {
+            $batchId = $this->storage->claim();
+        }
         if ($batchId === '') {
             $this->logger->debug("[CacheDebounce] Nothing to flush");
             return;
@@ -57,6 +70,7 @@ class Entries
         $tags = $this->storage->tags($batchId);
         $this->logger->debug("[CacheDebounce] Flushing Tags: " . json_encode($tags));
         $this->config->setShouldDebouncePurgeRequest(false);
+        $start = microtime(true);
 
         try {
             $success = $this->purgeCache->sendPurgeRequest($tags);
@@ -80,5 +94,8 @@ class Entries
         } finally {
             $this->config->setShouldDebouncePurgeRequest(true);
         }
+
+        $this->flagManager->saveFlag(self::FLAG_LAST_FLUSH_AT, date('Y-m-d H:i:s'));
+        $this->flagManager->saveFlag(self::FLAG_LAST_FLUSH_DURATION, round(microtime(true) - $start, 1));
     }
 }

--- a/Model/Entries.php
+++ b/Model/Entries.php
@@ -5,17 +5,14 @@ declare(strict_types=1);
 namespace SamJUK\CacheDebounce\Model;
 
 use SamJUK\CacheDebounce\Model\Config;
+use SamJUK\CacheDebounce\Model\Storage\QueueStorageInterface;
 use Magento\CacheInvalidate\Model\PurgeCache;
-use Magento\Framework\App\ResourceConnection;
 use Psr\Log\LoggerInterface;
 
 class Entries
 {
-    /** @var string $tableName */
-    private $tableName;
-
-    /** @var ResourceConnection $resourceConnection */
-    private $resourceConnection;
+    /** @var QueueStorageInterface $storage */
+    private $storage;
 
     /** @var PurgeCache $purgeCache */
     private $purgeCache;
@@ -29,14 +26,13 @@ class Entries
     public function __construct(
         Config $config,
         PurgeCache $purgeCache,
-        ResourceConnection $resourceConnection,
+        QueueStorageInterface $storage,
         LoggerInterface $logger
     ) {
         $this->config = $config;
         $this->purgeCache = $purgeCache;
-        $this->resourceConnection = $resourceConnection;
+        $this->storage = $storage;
         $this->logger = $logger;
-        $this->tableName = $resourceConnection->getTableName('samjuk_cache_debounce');
     }
 
     /**
@@ -44,22 +40,7 @@ class Entries
      */
     public function add(array $tags) : void
     {
-        if (!$tags) {
-            return;
-        }
-
-        $this->resourceConnection->getConnection()
-            ->insertArray($this->tableName, ['tag'], $tags);
-    }
-
-    /**
-     * Get all tags from the purge queue
-     */
-    public function get() : array
-    {
-        $connection = $this->resourceConnection->getConnection();
-        $query = $connection->select()->from($this->tableName, 'tag')->distinct();
-        return $connection->fetchCol($query);
+        $this->storage->add($tags);
     }
 
     /**
@@ -67,12 +48,13 @@ class Entries
      */
     public function flush() : void
     {
-        $tags = $this->get();
-        if (count($tags) === 0) {
+        $batchId = $this->storage->claim();
+        if ($batchId === '') {
             $this->logger->debug("[CacheDebounce] Nothing to flush");
             return;
         }
 
+        $tags = $this->storage->tags($batchId);
         $this->logger->debug("[CacheDebounce] Flushing Tags: " . json_encode($tags));
         $this->config->setShouldDebouncePurgeRequest(false);
 
@@ -81,12 +63,20 @@ class Entries
 
             if (!$success) {
                 $this->logger->error(
-                    "[CacheDebounce] Purge request failed — leaving tags queued for retry: " . json_encode($tags)
+                    "[CacheDebounce] Purge request failed — releasing batch $batchId for retry: "
+                        . json_encode($tags)
                 );
+                $this->storage->release($batchId);
                 return;
             }
 
-            $this->resourceConnection->getConnection()->delete($this->tableName);
+            $this->storage->clear($batchId);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                "[CacheDebounce] Purge request threw — releasing batch $batchId for retry: " . $e->getMessage()
+            );
+            $this->storage->release($batchId);
+            throw $e;
         } finally {
             $this->config->setShouldDebouncePurgeRequest(true);
         }

--- a/Model/LagDetector.php
+++ b/Model/LagDetector.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Model;
+
+use Magento\Framework\FlagManager;
+use Magento\Framework\Notification\NotifierInterface;
+use Psr\Log\LoggerInterface;
+
+class LagDetector
+{
+    public const FLAG_CONSECUTIVE_LAGGING_RUNS = 'samjuk_cache_debounce_consecutive_lagging_runs';
+
+    /** @var Config $config */
+    private $config;
+
+    /** @var FlagManager $flagManager */
+    private $flagManager;
+
+    /** @var NotifierInterface $notifier */
+    private $notifier;
+
+    /** @var LoggerInterface $logger */
+    private $logger;
+
+    public function __construct(
+        Config $config,
+        FlagManager $flagManager,
+        NotifierInterface $notifier,
+        LoggerInterface $logger
+    ) {
+        $this->config = $config;
+        $this->flagManager = $flagManager;
+        $this->notifier = $notifier;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Tracks consecutive lagging runs, re-notifying every N runs while it lasts.
+     */
+    public function recordSample(int $claimed, int $arrivedDuring): void
+    {
+        $isLagging = $claimed > 0
+            && ($arrivedDuring / $claimed) >= $this->config->getStaggerLagRatioThreshold();
+
+        if (!$isLagging) {
+            $this->flagManager->deleteFlag(self::FLAG_CONSECUTIVE_LAGGING_RUNS);
+            return;
+        }
+
+        $consecutiveRuns = (int)$this->flagManager->getFlagData(self::FLAG_CONSECUTIVE_LAGGING_RUNS) + 1;
+        $this->flagManager->saveFlag(self::FLAG_CONSECUTIVE_LAGGING_RUNS, $consecutiveRuns);
+
+        $alertAfterRuns = $this->config->getStaggerLagAlertAfterRuns();
+        if ($alertAfterRuns > 0 && $consecutiveRuns % $alertAfterRuns === 0) {
+            $message = sprintf(
+                'Purge release is lagging behind ingestion: %d tags arrived while %d were being drained '
+                    . '(%d consecutive lagging runs).',
+                $arrivedDuring,
+                $claimed,
+                $consecutiveRuns
+            );
+
+            $this->logger->warning("[CacheDebounce] $message");
+
+            // NotifierInterface has no addWarning() — addMajor is the closest severity.
+            $this->notifier->addMajor('Cache Debounce: purge release is lagging', $message);
+        }
+    }
+}

--- a/Model/StaggeredFlush.php
+++ b/Model/StaggeredFlush.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Model;
+
+use Magento\CacheInvalidate\Model\PurgeCache;
+use Magento\Framework\FlagManager;
+use Magento\Framework\Lock\LockManagerInterface;
+use Psr\Log\LoggerInterface;
+use SamJUK\CacheDebounce\Model\Storage\QueueStorageInterface;
+
+class StaggeredFlush
+{
+    private const LOCK_NAME = 'samjuk_cache_debounce_flush';
+    private const LOCK_TIMEOUT_FAIL_FAST = 0;
+
+    /** @var Config $config */
+    private $config;
+
+    /** @var QueueStorageInterface $storage */
+    private $storage;
+
+    /** @var PurgeCache $purgeCache */
+    private $purgeCache;
+
+    /** @var LockManagerInterface $lockManager */
+    private $lockManager;
+
+    /** @var LagDetector $lagDetector */
+    private $lagDetector;
+
+    /** @var FlagManager $flagManager */
+    private $flagManager;
+
+    /** @var Entries $entries */
+    private $entries;
+
+    /** @var LoggerInterface $logger */
+    private $logger;
+
+    public function __construct(
+        Config $config,
+        QueueStorageInterface $storage,
+        PurgeCache $purgeCache,
+        LockManagerInterface $lockManager,
+        LagDetector $lagDetector,
+        FlagManager $flagManager,
+        Entries $entries,
+        LoggerInterface $logger
+    ) {
+        $this->config = $config;
+        $this->storage = $storage;
+        $this->purgeCache = $purgeCache;
+        $this->lockManager = $lockManager;
+        $this->lagDetector = $lagDetector;
+        $this->flagManager = $flagManager;
+        $this->entries = $entries;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Releases a batch paced by the `stagger` config; single-shot when disabled.
+     */
+    public function execute(): void
+    {
+        if (!$this->config->isStaggerEnabled()) {
+            $this->entries->flush();
+            return;
+        }
+
+        if (!$this->lockManager->lock(self::LOCK_NAME, self::LOCK_TIMEOUT_FAIL_FAST)) {
+            $this->logger->debug('[CacheDebounce] Staggered release already running, skipping.');
+            return;
+        }
+
+        try {
+            $this->release();
+        } finally {
+            $this->lockManager->unlock(self::LOCK_NAME);
+        }
+    }
+
+    private function release(): void
+    {
+        $wasResumed = true;
+        $batchId = $this->storage->activeBatch();
+        if ($batchId === '') {
+            $wasResumed = false;
+            $batchId = $this->storage->claim();
+            if ($batchId === '') {
+                $this->logger->debug('[CacheDebounce] Nothing to flush.');
+                return;
+            }
+        }
+
+        // Always re-purges the full batch, even on resume — a BAN is idempotent.
+        $tags = $this->storage->tags($batchId);
+        $claimedCount = count($tags);
+        $chunks = array_chunk($tags, max(1, $this->config->getStaggerBatchSize()));
+        $lastChunkIndex = count($chunks) - 1;
+        $intervalMicroseconds = max(0, $this->config->getStaggerIntervalMs()) * 1000;
+        $maxRuntimeSeconds = $this->config->getStaggerMaxRuntimeSeconds();
+        $start = microtime(true);
+
+        $this->config->setShouldDebouncePurgeRequest(false);
+        try {
+            foreach ($chunks as $index => $chunk) {
+                // Budget only checked from chunk 2 on, so a bad config can't block all progress.
+                if ($index > 0 && (microtime(true) - $start) >= $maxRuntimeSeconds) {
+                    $this->logger->debug(
+                        "[CacheDebounce] Staggered release hit its runtime budget; "
+                            . "batch $batchId stays claimed for the next run."
+                    );
+                    return;
+                }
+
+                if (!$this->purgeCache->sendPurgeRequest($chunk)) {
+                    $this->logger->error(
+                        "[CacheDebounce] Staggered purge chunk failed — leaving batch $batchId queued for retry."
+                    );
+                    return;
+                }
+
+                if ($index !== $lastChunkIndex) {
+                    usleep($intervalMicroseconds);
+                }
+            }
+        } finally {
+            $this->config->setShouldDebouncePurgeRequest(true);
+        }
+
+        $this->storage->clear($batchId);
+
+        $this->flagManager->saveFlag(Entries::FLAG_LAST_FLUSH_AT, date('Y-m-d H:i:s'));
+        $this->flagManager->saveFlag(Entries::FLAG_LAST_FLUSH_DURATION, round(microtime(true) - $start, 1));
+
+        // Skip on resume — pendingCount() would include pre-run backlog too.
+        if (!$wasResumed) {
+            $this->lagDetector->recordSample($claimedCount, $this->storage->pendingCount());
+        }
+    }
+}

--- a/Model/Storage/Database.php
+++ b/Model/Storage/Database.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Model\Storage;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+
+class Database implements QueueStorageInterface
+{
+    private const UNCLAIMED_BATCH_ID = '';
+
+    /** @var string $tableName */
+    private $tableName;
+
+    /** @var ResourceConnection $resourceConnection */
+    private $resourceConnection;
+
+    public function __construct(
+        ResourceConnection $resourceConnection
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->tableName = $resourceConnection->getTableName('samjuk_cache_debounce');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Dedupes against pending tags at the app level; no PK for this yet.
+     */
+    public function add(array $tags): void
+    {
+        $tags = array_values(array_unique(array_filter($tags, fn ($tag) => $tag !== null && $tag !== '')));
+        if (!$tags) {
+            return;
+        }
+
+        $newTags = array_diff($tags, $this->tags(self::UNCLAIMED_BATCH_ID));
+        if (!$newTags) {
+            return;
+        }
+
+        $rows = [];
+        foreach ($newTags as $tag) {
+            $rows[] = [self::UNCLAIMED_BATCH_ID, $tag];
+        }
+
+        $this->resourceConnection->getConnection()->insertArray(
+            $this->tableName,
+            ['batch_id', 'tag'],
+            $rows,
+            AdapterInterface::INSERT_IGNORE
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function claim(): string
+    {
+        $batchId = bin2hex(random_bytes(16));
+
+        $affectedRows = $this->resourceConnection->getConnection()->update(
+            $this->tableName,
+            ['batch_id' => $batchId],
+            $this->quoteBatchId(self::UNCLAIMED_BATCH_ID)
+        );
+
+        return $affectedRows > 0 ? $batchId : '';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tags(string $batchId): array
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $query = $connection->select()
+            ->from($this->tableName, 'tag')
+            ->where('batch_id = ?', $batchId);
+
+        return $connection->fetchCol($query);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(string $batchId): void
+    {
+        $this->resourceConnection->getConnection()->delete(
+            $this->tableName,
+            $this->quoteBatchId($batchId)
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function release(string $batchId): void
+    {
+        $this->add($this->tags($batchId));
+        $this->clear($batchId);
+    }
+
+    private function quoteBatchId(string $batchId): string
+    {
+        return $this->resourceConnection->getConnection()->quoteInto('batch_id = ?', $batchId);
+    }
+}

--- a/Model/Storage/Database.php
+++ b/Model/Storage/Database.php
@@ -107,4 +107,48 @@ class Database implements QueueStorageInterface
     {
         return $this->resourceConnection->getConnection()->quoteInto('batch_id = ?', $batchId);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function pendingCount(): int
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $query = $connection->select()
+            ->from($this->tableName, ['count' => 'COUNT(*)'])
+            ->where('batch_id = ?', self::UNCLAIMED_BATCH_ID);
+
+        return (int)$connection->fetchOne($query);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function activeBatch(): string
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $query = $connection->select()
+            ->from($this->tableName, ['batch_id'])
+            ->where('batch_id != ?', self::UNCLAIMED_BATCH_ID)
+            ->limit(1);
+
+        $batchId = $connection->fetchOne($query);
+
+        return $batchId !== false ? (string)$batchId : '';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function oldestPendingAgeSeconds(): ?int
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $query = $connection->select()
+            ->from($this->tableName, ['age' => 'TIMESTAMPDIFF(SECOND, MIN(created_at), NOW())'])
+            ->where('batch_id = ?', self::UNCLAIMED_BATCH_ID);
+
+        $age = $connection->fetchOne($query);
+
+        return ($age === null || $age === false) ? null : max(0, (int)$age);
+    }
 }

--- a/Model/Storage/Pool.php
+++ b/Model/Storage/Pool.php
@@ -74,6 +74,30 @@ class Pool implements QueueStorageInterface
         $this->driver()->release($batchId);
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function pendingCount(): int
+    {
+        return $this->driver()->pendingCount();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function activeBatch(): string
+    {
+        return $this->driver()->activeBatch();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function oldestPendingAgeSeconds(): ?int
+    {
+        return $this->driver()->oldestPendingAgeSeconds();
+    }
+
     private function driver(): QueueStorageInterface
     {
         if ($this->resolved === null) {

--- a/Model/Storage/Pool.php
+++ b/Model/Storage/Pool.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Model\Storage;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\ObjectManagerInterface;
+
+class Pool implements QueueStorageInterface
+{
+    private const XML_PATH_STORAGE_DRIVER = 'samjuk_cache_debounce_advanced/general/storage_driver';
+    private const DEFAULT_DRIVER = 'db';
+
+    /** @var ObjectManagerInterface $objectManager */
+    private $objectManager;
+
+    /** @var ScopeConfigInterface $scopeConfig */
+    private $scopeConfig;
+
+    /** @var string[] $drivers */
+    private $drivers;
+
+    /** @var QueueStorageInterface|null $resolved */
+    private $resolved;
+
+    public function __construct(
+        ObjectManagerInterface $objectManager,
+        ScopeConfigInterface $scopeConfig,
+        array $drivers = []
+    ) {
+        $this->objectManager = $objectManager;
+        $this->scopeConfig = $scopeConfig;
+        $this->drivers = $drivers;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function add(array $tags): void
+    {
+        $this->driver()->add($tags);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function claim(): string
+    {
+        return $this->driver()->claim();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tags(string $batchId): array
+    {
+        return $this->driver()->tags($batchId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(string $batchId): void
+    {
+        $this->driver()->clear($batchId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function release(string $batchId): void
+    {
+        $this->driver()->release($batchId);
+    }
+
+    private function driver(): QueueStorageInterface
+    {
+        if ($this->resolved === null) {
+            $key = (string)$this->scopeConfig->getValue(self::XML_PATH_STORAGE_DRIVER) ?: self::DEFAULT_DRIVER;
+            $class = $this->drivers[$key] ?? $this->drivers[self::DEFAULT_DRIVER];
+            $this->resolved = $this->objectManager->create($class);
+        }
+
+        return $this->resolved;
+    }
+}

--- a/Model/Storage/QueueStorageInterface.php
+++ b/Model/Storage/QueueStorageInterface.php
@@ -30,4 +30,20 @@ interface QueueStorageInterface
      * Release a claimed batch back to pending, merging idempotently.
      */
     public function release(string $batchId): void;
+
+    /**
+     * Count of currently pending (unclaimed) tags.
+     */
+    public function pendingCount(): int;
+
+    /**
+     * Id of an already-claimed, not-yet-cleared batch, if one exists.
+     * Returns '' if nothing is currently claimed.
+     */
+    public function activeBatch(): string;
+
+    /**
+     * Age in seconds of the oldest pending tag; null if none or unknown.
+     */
+    public function oldestPendingAgeSeconds(): ?int;
 }

--- a/Model/Storage/QueueStorageInterface.php
+++ b/Model/Storage/QueueStorageInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Model\Storage;
+
+interface QueueStorageInterface
+{
+    /**
+     * Queue tags for a future purge. Must be idempotent and no-op on empty.
+     */
+    public function add(array $tags): void;
+
+    /**
+     * Atomically carve off pending tags into a new batch; '' if none.
+     */
+    public function claim(): string;
+
+    /**
+     * Read the tags belonging to a previously claimed batch.
+     */
+    public function tags(string $batchId): array;
+
+    /**
+     * Delete a claimed batch. Never touches pending (unclaimed) rows.
+     */
+    public function clear(string $batchId): void;
+
+    /**
+     * Release a claimed batch back to pending, merging idempotently.
+     */
+    public function release(string $batchId): void;
+}

--- a/Model/Storage/Redis.php
+++ b/Model/Storage/Redis.php
@@ -10,6 +10,7 @@ class Redis implements QueueStorageInterface
 {
     private const KEY_LIVE = 'samjuk_cache_debounce:queue:live';
     private const KEY_BATCH_PREFIX = 'samjuk_cache_debounce:queue:batch:';
+    private const KEY_ACTIVE_BATCH = 'samjuk_cache_debounce:queue:active_batch_id';
 
     /** @var ConnectionResolver $connectionResolver */
     private $connectionResolver;
@@ -38,15 +39,18 @@ class Redis implements QueueStorageInterface
     public function claim(): string
     {
         $batchId = bin2hex(random_bytes(16));
+        $client = $this->connectionResolver->getClient();
 
         try {
-            $this->connectionResolver->getClient()->rename(self::KEY_LIVE, self::KEY_BATCH_PREFIX . $batchId);
+            $client->rename(self::KEY_LIVE, self::KEY_BATCH_PREFIX . $batchId);
         } catch (\CredisException $e) {
             if (stripos($e->getMessage(), 'no such key') !== false) {
                 return '';
             }
             throw $e;
         }
+
+        $client->set(self::KEY_ACTIVE_BATCH, $batchId);
 
         return $batchId;
     }
@@ -64,7 +68,9 @@ class Redis implements QueueStorageInterface
      */
     public function clear(string $batchId): void
     {
-        $this->connectionResolver->getClient()->del(self::KEY_BATCH_PREFIX . $batchId);
+        $client = $this->connectionResolver->getClient();
+        $client->del(self::KEY_BATCH_PREFIX . $batchId);
+        $client->del(self::KEY_ACTIVE_BATCH);
     }
 
     /**
@@ -75,5 +81,35 @@ class Redis implements QueueStorageInterface
         $client = $this->connectionResolver->getClient();
         $client->sUnionStore(self::KEY_LIVE, self::KEY_LIVE, self::KEY_BATCH_PREFIX . $batchId);
         $client->del(self::KEY_BATCH_PREFIX . $batchId);
+        $client->del(self::KEY_ACTIVE_BATCH);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function pendingCount(): int
+    {
+        return (int)$this->connectionResolver->getClient()->sCard(self::KEY_LIVE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function activeBatch(): string
+    {
+        $batchId = $this->connectionResolver->getClient()->get(self::KEY_ACTIVE_BATCH);
+
+        return $batchId !== false && $batchId !== null ? (string)$batchId : '';
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * A Redis Set has no per-member insertion time, so this driver can't
+     * answer this — always null.
+     */
+    public function oldestPendingAgeSeconds(): ?int
+    {
+        return null;
     }
 }

--- a/Model/Storage/Redis.php
+++ b/Model/Storage/Redis.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Model\Storage;
+
+use SamJUK\CacheDebounce\Model\Storage\Redis\ConnectionResolver;
+
+class Redis implements QueueStorageInterface
+{
+    private const KEY_LIVE = 'samjuk_cache_debounce:queue:live';
+    private const KEY_BATCH_PREFIX = 'samjuk_cache_debounce:queue:batch:';
+
+    /** @var ConnectionResolver $connectionResolver */
+    private $connectionResolver;
+
+    public function __construct(
+        ConnectionResolver $connectionResolver
+    ) {
+        $this->connectionResolver = $connectionResolver;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function add(array $tags): void
+    {
+        if (!$tags) {
+            return;
+        }
+
+        $this->connectionResolver->getClient()->sAdd(self::KEY_LIVE, ...$tags);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function claim(): string
+    {
+        $batchId = bin2hex(random_bytes(16));
+
+        try {
+            $this->connectionResolver->getClient()->rename(self::KEY_LIVE, self::KEY_BATCH_PREFIX . $batchId);
+        } catch (\CredisException $e) {
+            if (stripos($e->getMessage(), 'no such key') !== false) {
+                return '';
+            }
+            throw $e;
+        }
+
+        return $batchId;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tags(string $batchId): array
+    {
+        return $this->connectionResolver->getClient()->sMembers(self::KEY_BATCH_PREFIX . $batchId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(string $batchId): void
+    {
+        $this->connectionResolver->getClient()->del(self::KEY_BATCH_PREFIX . $batchId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function release(string $batchId): void
+    {
+        $client = $this->connectionResolver->getClient();
+        $client->sUnionStore(self::KEY_LIVE, self::KEY_LIVE, self::KEY_BATCH_PREFIX . $batchId);
+        $client->del(self::KEY_BATCH_PREFIX . $batchId);
+    }
+}

--- a/Model/Storage/Redis/ConnectionResolver.php
+++ b/Model/Storage/Redis/ConnectionResolver.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Model\Storage\Redis;
+
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Exception\LocalizedException;
+
+class ConnectionResolver
+{
+    private const CONFIG_PATH_DEDICATED = 'cache_debounce/redis';
+    private const CONFIG_PATH_SHARED_FALLBACK = 'cache/frontend/page_cache/backend_options';
+
+    /** @var DeploymentConfig $deploymentConfig */
+    private $deploymentConfig;
+
+    /** @var \Credis_Client|null $client */
+    private $client;
+
+    public function __construct(
+        DeploymentConfig $deploymentConfig
+    ) {
+        $this->deploymentConfig = $deploymentConfig;
+    }
+
+    /**
+     * @throws LocalizedException when no usable connection can be resolved.
+     */
+    public function getClient(): \Credis_Client
+    {
+        if ($this->client !== null) {
+            return $this->client;
+        }
+
+        $dedicated = $this->deploymentConfig->get(self::CONFIG_PATH_DEDICATED);
+        $config = $dedicated ? $this->normalize($dedicated) : $this->resolveFallback();
+
+        if (!$config) {
+            throw new LocalizedException(__(
+                'SamJUK_CacheDebounce: no Redis connection could be resolved. Configure the '
+                . '"cache_debounce.redis" block in app/etc/env.php, or configure a Redis backend '
+                . 'for the "page_cache" cache frontend.'
+            ));
+        }
+
+        $this->client = new \Credis_Client(
+            $config['host'],
+            (int)$config['port'],
+            null,
+            '',
+            (int)$config['database'],
+            $config['password'] ?: null
+        );
+
+        return $this->client;
+    }
+
+    private function resolveFallback(): ?array
+    {
+        $backendOptions = $this->deploymentConfig->get(self::CONFIG_PATH_SHARED_FALLBACK);
+
+        if (!$backendOptions) {
+            return null;
+        }
+
+        return [
+            'host' => $backendOptions['server'] ?? '127.0.0.1',
+            'port' => $backendOptions['port'] ?? 6379,
+            'password' => $backendOptions['password'] ?? '',
+            'database' => $backendOptions['database'] ?? 0,
+        ];
+    }
+
+    /**
+     * Fill in defaults for whichever of host/port/database/password the
+     * "cache_debounce.redis" env.php block leaves out.
+     */
+    private function normalize(array $config): array
+    {
+        return [
+            'host' => $config['host'] ?? '127.0.0.1',
+            'port' => $config['port'] ?? 6379,
+            'password' => $config['password'] ?? '',
+            'database' => $config['database'] ?? 0,
+        ];
+    }
+}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Option | Config Path | Default | Description
 --- | --- | --- | ---
 Enabled | `samjuk_cache_debounce/general/enabled` | `0` | Feature flag to toggle functionality of the module
 Flush Schedule | `samjuk_cache_debounce/cron/flush_schedule` | `*/5 0 0 0 0` | Cron schedule to run the scheduled flush
+Stagger Enabled | `samjuk_cache_debounce/stagger/enabled` | `0` | Release a claimed batch gradually instead of purging it all at once — see below
+Stagger Batch Size | `samjuk_cache_debounce/stagger/batch_size` | `50` | Tags per purge chunk
+Stagger Interval (ms) | `samjuk_cache_debounce/stagger/interval_ms` | `1000` | Pause between chunks
+Stagger Max Runtime (s) | `samjuk_cache_debounce/stagger/max_runtime_seconds` | `240` | Safety budget per cron/CLI invocation
+Stagger Lag Ratio Threshold | `samjuk_cache_debounce/stagger/lag_ratio_threshold` | `1.0` | A run counts as "lagging" if tags arriving during the drain ≥ this ratio of tags just drained
+Stagger Lag Alert After Runs | `samjuk_cache_debounce/stagger/lag_alert_after_runs` | `3` | Consecutive lagging runs before an admin notification is raised
 Storage Driver | `samjuk_cache_debounce_advanced/general/storage_driver` | `db` | Queue storage backend — `db` or `redis`. A deploy-time infra decision, not a store setting — see below
 
 This one is a deliberate exception to "Configuration can be handled via System configuration" above: it's hidden from Stores > Configuration entirely (`showInDefault`/`showInWebsite`/`showInStore` all `0`) and gated behind its own ACL resource (`SamJUK_CacheDebounce::storage_driver`) that isn't granted to any role by default. It exists only so `config:set` has a registered path to write to. Set it with:
@@ -45,6 +51,8 @@ This one is a deliberate exception to "Configuration can be handled via System c
 php bin/magento config:set samjuk_cache_debounce_advanced/general/storage_driver redis
 ```
 Add `-e` to lock it into `app/etc/env.php` instead of `core_config_data`, removing Admin overridability entirely.
+
+**Only switch drivers when the queue is empty** (`samjuk:cache-debounce:status` shows zero pending and no active batch). Each driver only sees its own storage — switching mid-flight leaves whatever was queued in the old backend stranded there, invisible to the new one, until something re-queues the same tags.
 
 ### Redis storage driver
 
@@ -63,6 +71,19 @@ The `redis` driver connects via a dedicated `app/etc/env.php` block:
 If that block is absent, the module falls back to whatever Redis backend is already configured for the `page_cache` cache frontend, so it works zero-config once the driver is switched on.
 
 > **Note:** sharing the page cache's Redis instance means pending purge tags are subject to that instance's `maxmemory-policy`. If it's `allkeys-lru`/`allkeys-lfu` (common for FPC), tags can be silently evicted under memory pressure. Configure a dedicated block above to avoid this.
+
+### Staggered / batched purge release
+
+On a large debounce window, a single `flush()` can send hundreds of tags to Varnish in one instant — a CPU/IO spike exactly when the store is under load. Enabling `stagger` releases a claimed batch gradually instead: chunked into `batch_size`-sized purge requests, paced by `interval_ms`, within a `max_runtime_seconds` budget per cron/CLI invocation. Both the cron job and `samjuk:cache-debounce:flush` route through this — a single-shot flush when disabled (the pre-existing behavior), a paced release when enabled.
+
+An interrupted run (deploy, OOM-kill, timeout) leaves its batch claimed but not cleared; the next invocation resumes it — by re-purging its full tag list, not from a persisted chunk offset. A Varnish BAN is idempotent, so the cost of that is, at worst, a handful of redundant purges.
+
+Only one release runs at a time, guarded by `Magento\Framework\Lock\LockManagerInterface`. If release throughput can't keep up with ingestion, it's logged as a warning, surfaced in the admin bell-icon notifications after `lag_alert_after_runs` consecutive lagging runs, and re-raised every `lag_alert_after_runs` runs for as long as the condition persists.
+
+Check current state with:
+```sh
+php bin/magento samjuk:cache-debounce:status
+```
 
 ### Adding your own storage driver
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,45 @@ Option | Config Path | Default | Description
 --- | --- | --- | ---
 Enabled | `samjuk_cache_debounce/general/enabled` | `0` | Feature flag to toggle functionality of the module
 Flush Schedule | `samjuk_cache_debounce/cron/flush_schedule` | `*/5 0 0 0 0` | Cron schedule to run the scheduled flush
+Storage Driver | `samjuk_cache_debounce_advanced/general/storage_driver` | `db` | Queue storage backend — `db` or `redis`. A deploy-time infra decision, not a store setting — see below
+
+This one is a deliberate exception to "Configuration can be handled via System configuration" above: it's hidden from Stores > Configuration entirely (`showInDefault`/`showInWebsite`/`showInStore` all `0`) and gated behind its own ACL resource (`SamJUK_CacheDebounce::storage_driver`) that isn't granted to any role by default. It exists only so `config:set` has a registered path to write to. Set it with:
+```sh
+php bin/magento config:set samjuk_cache_debounce_advanced/general/storage_driver redis
+```
+Add `-e` to lock it into `app/etc/env.php` instead of `core_config_data`, removing Admin overridability entirely.
+
+### Redis storage driver
+
+The `redis` driver connects via a dedicated `app/etc/env.php` block:
+```php
+'cache_debounce' => [
+    'redis' => [
+        'host' => '127.0.0.1',
+        'port' => '6379',
+        'password' => '',
+        'database' => '2',
+    ],
+],
+```
+
+If that block is absent, the module falls back to whatever Redis backend is already configured for the `page_cache` cache frontend, so it works zero-config once the driver is switched on.
+
+> **Note:** sharing the page cache's Redis instance means pending purge tags are subject to that instance's `maxmemory-policy`. If it's `allkeys-lru`/`allkeys-lfu` (common for FPC), tags can be silently evicted under memory pressure. Configure a dedicated block above to avoid this.
+
+### Adding your own storage driver
+
+Drivers are resolved from an array bound in `etc/di.xml`, keyed by the value of `storage_driver`. Any module can add an entry to extend it, without touching this module's `di.xml`:
+```xml
+<type name="SamJUK\CacheDebounce\Model\Storage\Pool">
+    <arguments>
+        <argument name="drivers" xsi:type="array">
+            <item name="my_driver" xsi:type="string">Vendor\Module\Model\Storage\MyDriver</item>
+        </argument>
+    </arguments>
+</type>
+```
+`MyDriver` just needs to implement `QueueStorageInterface`. Then `bin/magento config:set samjuk_cache_debounce_advanced/general/storage_driver my_driver`.
 
 ## Will this help my store?
 

--- a/Setup/Patch/Data/ClearQueueTable.php
+++ b/Setup/Patch/Data/ClearQueueTable.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Setup\Patch\Data;
+
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+/**
+ * Clears disposable queue state before a follow-up release adds a PK.
+ */
+class ClearQueueTable implements DataPatchInterface
+{
+    /** @var ModuleDataSetupInterface $moduleDataSetup */
+    private $moduleDataSetup;
+
+    public function __construct(ModuleDataSetupInterface $moduleDataSetup)
+    {
+        $this->moduleDataSetup = $moduleDataSetup;
+    }
+
+    public function apply(): void
+    {
+        // DELETE not TRUNCATE: data patches run inside a transaction.
+        $connection = $this->moduleDataSetup->getConnection();
+        $connection->delete($this->moduleDataSetup->getTable('samjuk_cache_debounce'));
+    }
+
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    public function getAliases(): array
+    {
+        return [];
+    }
+}

--- a/Test/Integration/Model/EntriesTest.php
+++ b/Test/Integration/Model/EntriesTest.php
@@ -3,7 +3,10 @@
 namespace SamJUK\CacheDebounce\Test\Integration\Model;
 
 use PHPUnit\Framework\TestCase;
+use Magento\Framework\App\ResourceConnection;
 use Magento\TestFramework\ObjectManager;
+use SamJUK\CacheDebounce\Model\Entries;
+use SamJUK\CacheDebounce\Model\Storage\QueueStorageInterface;
 
 class EntriesTest extends TestCase
 {
@@ -11,19 +14,74 @@ class EntriesTest extends TestCase
 
     protected $objectManager;
     private $cacheDebouncedEntries;
+    private $storage;
+    private $resourceConnection;
 
     protected function setUp(): void
     {
         $this->objectManager = ObjectManager::getInstance();
-        $this->cacheDebouncedEntries = $this->objectManager->get(\SamJUK\CacheDebounce\Model\Entries::class);
+        $this->cacheDebouncedEntries = $this->objectManager->get(Entries::class);
+        $this->storage = $this->objectManager->get(QueueStorageInterface::class);
+
+        // Independent of the classes under test, so a prior test failing
+        // mid-assertion can never leak rows into the next test.
+        $this->resourceConnection = $this->objectManager->get(ResourceConnection::class);
+        $this->truncateTable();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->truncateTable();
+    }
+
+    private function truncateTable(): void
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $connection->delete($this->resourceConnection->getTableName('samjuk_cache_debounce'));
     }
 
     public function testDebouncedEntriesStorage()
     {
         $this->cacheDebouncedEntries->add(self::CACHE_TAGS);
-        $this->assertEquals(self::CACHE_TAGS, $this->cacheDebouncedEntries->get());
 
-        $this->cacheDebouncedEntries->flush();
-        $this->assertEquals([], $this->cacheDebouncedEntries->get());
+        $batchId = $this->storage->claim();
+        $this->assertEquals(self::CACHE_TAGS, $this->storage->tags($batchId));
+
+        $this->storage->clear($batchId);
+        $this->assertEquals([], $this->storage->tags($batchId));
+    }
+
+    /**
+     * Regression test for the add-during-purge race: a tag queued after a
+     * batch has been claimed must survive into the *next* batch, not be
+     * silently dropped by the trailing clear() of the batch currently
+     * being purged.
+     */
+    public function testTagAddedWhileBatchIsClaimedSurvivesIntoNextBatch()
+    {
+        $this->cacheDebouncedEntries->add(['cat_c_1']);
+
+        $batchId = $this->storage->claim();
+
+        $this->cacheDebouncedEntries->add(['cat_c_2']);
+
+        $this->assertEquals(['cat_c_1'], $this->storage->tags($batchId));
+
+        $this->storage->clear($batchId);
+
+        $nextBatchId = $this->storage->claim();
+        $this->assertEquals(['cat_c_2'], $this->storage->tags($nextBatchId));
+    }
+
+    public function testSecondConcurrentClaimReturnsEmptyString()
+    {
+        $this->cacheDebouncedEntries->add(self::CACHE_TAGS);
+
+        $batchId = $this->storage->claim();
+        $this->assertNotSame('', $batchId);
+
+        $this->assertSame('', $this->storage->claim());
+
+        $this->storage->clear($batchId);
     }
 }

--- a/Test/Integration/Model/StaggeredFlushTest.php
+++ b/Test/Integration/Model/StaggeredFlushTest.php
@@ -1,0 +1,123 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Integration\Model;
+
+use PHPUnit\Framework\TestCase;
+use Magento\CacheInvalidate\Model\PurgeCache;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Lock\LockManagerInterface;
+use Magento\TestFramework\ObjectManager;
+use SamJUK\CacheDebounce\Model\Entries;
+use SamJUK\CacheDebounce\Model\StaggeredFlush;
+use SamJUK\CacheDebounce\Model\Storage\QueueStorageInterface;
+
+/**
+ * @magentoConfigFixture samjuk_cache_debounce/stagger/enabled 1
+ * @magentoConfigFixture samjuk_cache_debounce/stagger/batch_size 1
+ * @magentoConfigFixture samjuk_cache_debounce/stagger/interval_ms 0
+ * @magentoConfigFixture samjuk_cache_debounce/stagger/max_runtime_seconds 240
+ */
+class StaggeredFlushTest extends TestCase
+{
+    private const LOCK_NAME = 'samjuk_cache_debounce_flush';
+
+    protected $objectManager;
+    private $storage;
+    private $entries;
+    private $resourceConnection;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = ObjectManager::getInstance();
+        $this->storage = $this->objectManager->get(QueueStorageInterface::class);
+        $this->entries = $this->objectManager->get(Entries::class);
+
+        // Independent of the classes under test, so a prior test failing
+        // mid-assertion can never leak rows into the next test.
+        $this->resourceConnection = $this->objectManager->get(ResourceConnection::class);
+        $this->truncateTable();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->truncateTable();
+        $this->objectManager->removeSharedInstance(PurgeCache::class);
+    }
+
+    private function truncateTable(): void
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $connection->delete($this->resourceConnection->getTableName('samjuk_cache_debounce'));
+    }
+
+    /**
+     * Double must be shared-instanced before create() resolves it.
+     */
+    private function staggeredFlushWithPurgeCache(PurgeCache $purgeCache): StaggeredFlush
+    {
+        $this->objectManager->addSharedInstance($purgeCache, PurgeCache::class);
+
+        return $this->objectManager->create(StaggeredFlush::class);
+    }
+
+    public function testInterruptedRunLeavesBatchClaimedAndTheNextRunResumesAndDrainsIt()
+    {
+        $this->entries->add(['cat_c_1', 'cat_c_2', 'cat_c_3']);
+
+        $calls = 0;
+        $crashingPurgeCache = $this->createMock(PurgeCache::class);
+        $crashingPurgeCache->method('sendPurgeRequest')->willReturnCallback(function ($tags) use (&$calls) {
+            $calls++;
+            if ($calls > 2) {
+                throw new \RuntimeException('simulated crash mid-loop');
+            }
+            return true;
+        });
+
+        try {
+            $this->staggeredFlushWithPurgeCache($crashingPurgeCache)->execute();
+            $this->fail('Expected the simulated crash to propagate.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('simulated crash mid-loop', $e->getMessage());
+        }
+
+        $batchId = $this->storage->activeBatch();
+        $this->assertNotSame('', $batchId, 'An interrupted batch must stay claimed for the next run.');
+
+        $healthyPurgeCache = $this->createMock(PurgeCache::class);
+        $healthyPurgeCache->method('sendPurgeRequest')->willReturn(true);
+
+        $this->staggeredFlushWithPurgeCache($healthyPurgeCache)->execute();
+
+        $this->assertSame('', $this->storage->activeBatch());
+        $this->assertSame(0, $this->storage->pendingCount());
+    }
+
+    public function testConcurrentInvocationsOnlyOneProceedsPastTheLock()
+    {
+        $this->entries->add(['cat_c_1']);
+
+        $purgeCache = $this->createMock(PurgeCache::class);
+        $purgeCache->method('sendPurgeRequest')->willReturn(true);
+        $staggeredFlush = $this->staggeredFlushWithPurgeCache($purgeCache);
+
+        $lockManager = $this->objectManager->get(LockManagerInterface::class);
+        $this->assertTrue($lockManager->lock(self::LOCK_NAME, 0));
+
+        try {
+            $staggeredFlush->execute();
+
+            // Lock held by us — the concurrent invocation must have backed
+            // off without touching the queue at all.
+            $this->assertSame(1, $this->storage->pendingCount());
+            $this->assertSame('', $this->storage->activeBatch());
+        } finally {
+            $lockManager->unlock(self::LOCK_NAME);
+        }
+
+        // Lock released — the next invocation proceeds and drains normally.
+        $staggeredFlush->execute();
+        $this->assertSame(0, $this->storage->pendingCount());
+        $this->assertSame('', $this->storage->activeBatch());
+    }
+}

--- a/Test/Integration/Model/Storage/DatabaseTest.php
+++ b/Test/Integration/Model/Storage/DatabaseTest.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Integration\Model\Storage;
+
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\App\ResourceConnection;
+use Magento\TestFramework\ObjectManager;
+use SamJUK\CacheDebounce\Model\Storage\Database;
+
+class DatabaseTest extends TestCase
+{
+    protected $objectManager;
+    private $storage;
+    private $resourceConnection;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = ObjectManager::getInstance();
+        $this->storage = $this->objectManager->create(Database::class);
+
+        // Independent of the class under test, so a prior test failing
+        // mid-assertion can never leak rows into the next test.
+        $this->resourceConnection = $this->objectManager->get(ResourceConnection::class);
+        $this->truncateTable();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->truncateTable();
+    }
+
+    private function truncateTable(): void
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $connection->delete($this->resourceConnection->getTableName('samjuk_cache_debounce'));
+    }
+
+    public function testAddClaimTagsClearRoundTrip()
+    {
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+
+        $batchId = $this->storage->claim();
+        $this->assertNotSame('', $batchId);
+
+        $this->assertEquals(['cat_c_1', 'cat_c_2'], $this->storage->tags($batchId));
+
+        $this->storage->clear($batchId);
+        $this->assertEquals([], $this->storage->tags($batchId));
+    }
+
+    public function testAddDuringClaimIsNotLostOrDuplicated()
+    {
+        $this->storage->add(['cat_c_1']);
+
+        $batchId = $this->storage->claim();
+
+        // Overlapping tag added after the claim snapshot — must land in the
+        // next batch, not be silently merged into the one already claimed.
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+
+        $this->assertEquals(['cat_c_1'], $this->storage->tags($batchId));
+
+        $this->storage->clear($batchId);
+
+        $nextBatchId = $this->storage->claim();
+        $this->assertEquals(['cat_c_1', 'cat_c_2'], $this->storage->tags($nextBatchId));
+    }
+
+    public function testAddDoesNotDuplicateAlreadyPendingTags()
+    {
+        $this->storage->add(['cat_c_1']);
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+
+        $batchId = $this->storage->claim();
+
+        $this->assertEquals(['cat_c_1', 'cat_c_2'], $this->storage->tags($batchId));
+    }
+
+    public function testAddIgnoresNullAndEmptyTags()
+    {
+        $this->storage->add(['cat_c_1', null, '']);
+
+        $batchId = $this->storage->claim();
+
+        $this->assertEquals(['cat_c_1'], $this->storage->tags($batchId));
+    }
+
+    public function testSecondConcurrentClaimReturnsEmptyString()
+    {
+        $this->storage->add(['cat_c_1']);
+
+        $firstBatchId = $this->storage->claim();
+        $this->assertNotSame('', $firstBatchId);
+
+        $this->assertSame('', $this->storage->claim());
+
+        $this->storage->clear($firstBatchId);
+    }
+
+    public function testReleaseMakesTheBatchClaimableAgain()
+    {
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+        $batchId = $this->storage->claim();
+
+        $this->storage->release($batchId);
+
+        $this->assertEquals([], $this->storage->tags($batchId));
+
+        $nextBatchId = $this->storage->claim();
+        $this->assertEquals(['cat_c_1', 'cat_c_2'], $this->storage->tags($nextBatchId));
+    }
+
+    public function testReleaseMergesCleanlyWithTagsReQueuedWhileClaimed()
+    {
+        $this->storage->add(['cat_c_1']);
+        $batchId = $this->storage->claim();
+
+        // Same tag re-queued while the original batch is still in flight —
+        // release() must not end up with two pending rows for it.
+        $this->storage->add(['cat_c_1']);
+
+        $this->storage->release($batchId);
+
+        $nextBatchId = $this->storage->claim();
+        $this->assertEquals(['cat_c_1'], $this->storage->tags($nextBatchId));
+    }
+}

--- a/Test/Integration/Model/Storage/DatabaseTest.php
+++ b/Test/Integration/Model/Storage/DatabaseTest.php
@@ -124,4 +124,33 @@ class DatabaseTest extends TestCase
         $nextBatchId = $this->storage->claim();
         $this->assertEquals(['cat_c_1'], $this->storage->tags($nextBatchId));
     }
+
+    public function testPendingCountAndActiveBatchReflectClaimState()
+    {
+        $this->assertSame(0, $this->storage->pendingCount());
+        $this->assertSame('', $this->storage->activeBatch());
+
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+        $this->assertSame(2, $this->storage->pendingCount());
+        $this->assertSame('', $this->storage->activeBatch());
+
+        $batchId = $this->storage->claim();
+        $this->assertSame(0, $this->storage->pendingCount());
+        $this->assertSame($batchId, $this->storage->activeBatch());
+
+        $this->storage->clear($batchId);
+        $this->assertSame('', $this->storage->activeBatch());
+    }
+
+    public function testOldestPendingAgeSecondsReflectsWhenTagsWereQueued()
+    {
+        $this->assertNull($this->storage->oldestPendingAgeSeconds());
+
+        $this->storage->add(['cat_c_1']);
+
+        $age = $this->storage->oldestPendingAgeSeconds();
+        $this->assertIsInt($age);
+        $this->assertGreaterThanOrEqual(0, $age);
+        $this->assertLessThan(10, $age);
+    }
 }

--- a/Test/Integration/Model/Storage/Redis/ConnectionResolverTest.php
+++ b/Test/Integration/Model/Storage/Redis/ConnectionResolverTest.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Integration\Model\Storage\Redis;
+
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\TestFramework\ObjectManager;
+use SamJUK\CacheDebounce\Model\Storage\Redis\ConnectionResolver;
+
+/**
+ * Requires a Redis server reachable at 127.0.0.1:6379.
+ */
+class ConnectionResolverTest extends TestCase
+{
+    private const CANARY_KEY = 'samjuk_cache_debounce:test:canary';
+    private const DEDICATED_DATABASE = 3;
+    private const FALLBACK_DATABASE = 4;
+
+    private $dedicatedResolver;
+    private $fallbackResolver;
+
+    protected function setUp(): void
+    {
+        $reader = ObjectManager::getInstance()->get(DeploymentConfig\Reader::class);
+
+        $dedicatedConfig = new DeploymentConfig($reader, ['cache_debounce' => ['redis' => [
+            'host' => '127.0.0.1',
+            'port' => '6379',
+            'password' => '',
+            'database' => (string)self::DEDICATED_DATABASE,
+        ]]]);
+        $fallbackConfig = new DeploymentConfig($reader, ['cache' => ['frontend' => ['page_cache' => [
+            'backend_options' => [
+                'server' => '127.0.0.1',
+                'port' => '6379',
+                'password' => '',
+                'database' => (string)self::FALLBACK_DATABASE,
+            ],
+        ]]]]);
+
+        $this->dedicatedResolver = new ConnectionResolver($dedicatedConfig);
+        $this->fallbackResolver = new ConnectionResolver($fallbackConfig);
+
+        $this->dedicatedResolver->getClient()->flushDb();
+        $this->fallbackResolver->getClient()->flushDb();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dedicatedResolver->getClient()->flushDb();
+        $this->fallbackResolver->getClient()->flushDb();
+    }
+
+    public function testResolvesTheDedicatedConnection()
+    {
+        $client = $this->dedicatedResolver->getClient();
+
+        $client->set(self::CANARY_KEY, '1');
+        $this->assertSame('1', $client->get(self::CANARY_KEY));
+    }
+
+    public function testFallsBackToThePageCacheConnectionWhenNoDedicatedBlockIsConfigured()
+    {
+        $client = $this->fallbackResolver->getClient();
+
+        $client->set(self::CANARY_KEY, '1');
+        $this->assertSame('1', $client->get(self::CANARY_KEY));
+    }
+}

--- a/Test/Integration/Model/Storage/RedisTest.php
+++ b/Test/Integration/Model/Storage/RedisTest.php
@@ -1,0 +1,119 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Integration\Model\Storage;
+
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\TestFramework\ObjectManager;
+use SamJUK\CacheDebounce\Model\Storage\Redis;
+use SamJUK\CacheDebounce\Model\Storage\Redis\ConnectionResolver;
+
+/**
+ * Requires a Redis server reachable at 127.0.0.1:6379.
+ */
+class RedisTest extends TestCase
+{
+    private const CONNECTION_CONFIG = [
+        'host' => '127.0.0.1',
+        'port' => '6379',
+        'password' => '',
+        'database' => '2',
+    ];
+
+    private $storage;
+    private $rawClient;
+
+    protected function setUp(): void
+    {
+        $reader = ObjectManager::getInstance()->get(DeploymentConfig\Reader::class);
+        $deploymentConfig = new DeploymentConfig($reader, ['cache_debounce' => ['redis' => self::CONNECTION_CONFIG]]);
+
+        $this->storage = new Redis(new ConnectionResolver($deploymentConfig));
+
+        // Independent resolver instance, not the class under test.
+        $this->rawClient = (new ConnectionResolver($deploymentConfig))->getClient();
+        $this->rawClient->flushDb();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rawClient->flushDb();
+    }
+
+    public function testAddClaimTagsClearRoundTrip()
+    {
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+
+        $batchId = $this->storage->claim();
+        $this->assertNotSame('', $batchId);
+
+        $tags = $this->storage->tags($batchId);
+        sort($tags);
+        $this->assertEquals(['cat_c_1', 'cat_c_2'], $tags);
+
+        $this->storage->clear($batchId);
+        $this->assertEquals([], $this->storage->tags($batchId));
+    }
+
+    public function testAddDuringClaimIsNotLostOrDuplicated()
+    {
+        $this->storage->add(['cat_c_1']);
+
+        $batchId = $this->storage->claim();
+
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+
+        $this->assertEquals(['cat_c_1'], $this->storage->tags($batchId));
+
+        $this->storage->clear($batchId);
+
+        $nextBatchId = $this->storage->claim();
+        $tags = $this->storage->tags($nextBatchId);
+        sort($tags);
+        $this->assertEquals(['cat_c_1', 'cat_c_2'], $tags);
+
+        $this->storage->clear($nextBatchId);
+    }
+
+    public function testSecondConcurrentClaimReturnsEmptyString()
+    {
+        $this->storage->add(['cat_c_1']);
+
+        $firstBatchId = $this->storage->claim();
+        $this->assertNotSame('', $firstBatchId);
+
+        $this->assertSame('', $this->storage->claim());
+
+        $this->storage->clear($firstBatchId);
+    }
+
+    public function testReleaseMakesTheBatchClaimableAgain()
+    {
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+        $batchId = $this->storage->claim();
+
+        $this->storage->release($batchId);
+
+        $this->assertEquals([], $this->storage->tags($batchId));
+
+        $nextBatchId = $this->storage->claim();
+        $tags = $this->storage->tags($nextBatchId);
+        sort($tags);
+        $this->assertEquals(['cat_c_1', 'cat_c_2'], $tags);
+    }
+
+    public function testReleaseMergesCleanlyWithTagsReQueuedWhileClaimed()
+    {
+        $this->storage->add(['cat_c_1']);
+        $batchId = $this->storage->claim();
+
+        // Same tag re-queued while the original batch is still in flight —
+        // release() must not duplicate it; Redis sets dedupe natively.
+        $this->storage->add(['cat_c_1']);
+
+        $this->storage->release($batchId);
+
+        $nextBatchId = $this->storage->claim();
+        $this->assertEquals(['cat_c_1'], $this->storage->tags($nextBatchId));
+    }
+}

--- a/Test/Integration/Model/Storage/RedisTest.php
+++ b/Test/Integration/Model/Storage/RedisTest.php
@@ -116,4 +116,28 @@ class RedisTest extends TestCase
         $nextBatchId = $this->storage->claim();
         $this->assertEquals(['cat_c_1'], $this->storage->tags($nextBatchId));
     }
+
+    public function testPendingCountAndActiveBatchReflectClaimState()
+    {
+        $this->assertSame(0, $this->storage->pendingCount());
+        $this->assertSame('', $this->storage->activeBatch());
+
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+        $this->assertSame(2, $this->storage->pendingCount());
+        $this->assertSame('', $this->storage->activeBatch());
+
+        $batchId = $this->storage->claim();
+        $this->assertSame(0, $this->storage->pendingCount());
+        $this->assertSame($batchId, $this->storage->activeBatch());
+
+        $this->storage->clear($batchId);
+        $this->assertSame('', $this->storage->activeBatch());
+    }
+
+    public function testOldestPendingAgeSecondsIsAlwaysNull()
+    {
+        $this->storage->add(['cat_c_1']);
+
+        $this->assertNull($this->storage->oldestPendingAgeSeconds());
+    }
 }

--- a/Test/Unit/Model/Config/Source/StorageDriverTest.php
+++ b/Test/Unit/Model/Config/Source/StorageDriverTest.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Unit\Model\Config\Source;
+
+use PHPUnit\Framework\TestCase;
+use SamJUK\CacheDebounce\Model\Config\Source\StorageDriver;
+
+class StorageDriverTest extends TestCase
+{
+    public function testToOptionArrayListsEachRegisteredDriver()
+    {
+        $values = array_column((new StorageDriver())->toOptionArray(), 'value');
+
+        $this->assertSame(['db', 'redis'], $values);
+    }
+}

--- a/Test/Unit/Model/ConfigTest.php
+++ b/Test/Unit/Model/ConfigTest.php
@@ -37,4 +37,33 @@ class ConfigTest extends TestCase
         $config->setShouldDebouncePurgeRequest(false);
         $this->assertFalse($config->shouldDebouncePurgeRequest());
     }
+
+    public function testIsStaggerEnabled()
+    {
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $config = new CacheDebounceConfig($scopeConfig);
+        $this->assertFalse($config->isStaggerEnabled());
+
+        $scopeConfig->method('isSetFlag')->willReturn(1);
+        $this->assertTrue($config->isStaggerEnabled());
+    }
+
+    public function testStaggerNumericGetters()
+    {
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->method('getValue')->willReturnMap([
+            ['samjuk_cache_debounce/stagger/batch_size', 'default', null, '50'],
+            ['samjuk_cache_debounce/stagger/interval_ms', 'default', null, '1000'],
+            ['samjuk_cache_debounce/stagger/max_runtime_seconds', 'default', null, '240'],
+            ['samjuk_cache_debounce/stagger/lag_ratio_threshold', 'default', null, '1.5'],
+            ['samjuk_cache_debounce/stagger/lag_alert_after_runs', 'default', null, '3'],
+        ]);
+        $config = new CacheDebounceConfig($scopeConfig);
+
+        $this->assertSame(50, $config->getStaggerBatchSize());
+        $this->assertSame(1000, $config->getStaggerIntervalMs());
+        $this->assertSame(240, $config->getStaggerMaxRuntimeSeconds());
+        $this->assertSame(1.5, $config->getStaggerLagRatioThreshold());
+        $this->assertSame(3, $config->getStaggerLagAlertAfterRuns());
+    }
 }

--- a/Test/Unit/Model/EntriesTest.php
+++ b/Test/Unit/Model/EntriesTest.php
@@ -2,69 +2,75 @@
 
 namespace SamJUK\CacheDebounce\Test\Unit\Model;
 
+use Magento\CacheInvalidate\Model\PurgeCache;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use SamJUK\CacheDebounce\Model\Config as CacheDebounceConfig;
 use SamJUK\CacheDebounce\Model\Entries as CacheDebounceEntries;
+use SamJUK\CacheDebounce\Model\Storage\QueueStorageInterface;
 
 class EntriesTest extends TestCase
 {
+    private const BATCH_ID = 'batch-123';
     private const CACHE_TAGS = ['cat_c_1', 'cat_c_2', 'cat_c_p_1'];
 
     private $cacheDebounceConfig;
     private $purgeCacheModel;
-    private $connection;
-    private $resourceConnection;
+    private $storage;
     private $loggerInterface;
     private $cacheDebounceEntries;
-    private $select;
 
     protected function setUp(): void
     {
-        $this->select = $this->createMock(\Magento\Framework\DB\Select::class);
-        $this->select->method('from')->willReturn($this->select);
-        $this->select->method('distinct')->willReturn($this->select);
-        $this->connection = $this->createMock(\Magento\Framework\DB\Adapter\AdapterInterface::class);
-        $this->connection->method('select')->willReturn($this->select);
-        $this->cacheDebounceConfig = $this->createMock(\SamJUK\CacheDebounce\Model\Config::class);
-        $this->resourceConnection = $this->createMock(\Magento\Framework\App\ResourceConnection::class);
-        $this->resourceConnection->method('getConnection')->willReturn($this->connection);
-        $this->purgeCacheModel = $this->createMock(\Magento\CacheInvalidate\Model\PurgeCache::class);
-        $this->loggerInterface = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $this->cacheDebounceConfig = $this->createMock(CacheDebounceConfig::class);
+        $this->storage = $this->createMock(QueueStorageInterface::class);
+        $this->purgeCacheModel = $this->createMock(PurgeCache::class);
+        $this->loggerInterface = $this->createMock(LoggerInterface::class);
         $this->cacheDebounceEntries = new CacheDebounceEntries(
             $this->cacheDebounceConfig,
             $this->purgeCacheModel,
-            $this->resourceConnection,
+            $this->storage,
             $this->loggerInterface
         );
     }
 
-    public function testFlushTags()
+    public function testFlushDoesNothingWhenNothingIsClaimed()
     {
-        $this->connection->method('fetchCol')->willReturn([
-            self::CACHE_TAGS
-        ]);
+        $this->storage->method('claim')->willReturn('');
 
-        $this->purgeCacheModel->expects($this->once())
-            ->method('sendPurgeRequest')
-            ->with([self::CACHE_TAGS])
-            ->willReturn(true);
-
-        $this->connection->expects($this->once())->method('delete');
+        $this->purgeCacheModel->expects($this->never())->method('sendPurgeRequest');
 
         $this->cacheDebounceEntries->flush();
     }
 
-    public function testFlushDoesNotClearQueueWhenPurgeRequestFails()
+    public function testFlushPurgesClaimedTagsAndClearsBatch()
     {
-        $this->connection->method('fetchCol')->willReturn([
-            self::CACHE_TAGS
-        ]);
+        $this->storage->method('claim')->willReturn(self::BATCH_ID);
+        $this->storage->method('tags')->with(self::BATCH_ID)->willReturn(self::CACHE_TAGS);
 
         $this->purgeCacheModel->expects($this->once())
             ->method('sendPurgeRequest')
-            ->with([self::CACHE_TAGS])
+            ->with(self::CACHE_TAGS)
+            ->willReturn(true);
+
+        $this->storage->expects($this->once())->method('clear')->with(self::BATCH_ID);
+
+        $this->cacheDebounceEntries->flush();
+    }
+
+    public function testFlushReleasesBatchInsteadOfClearingWhenPurgeRequestFails()
+    {
+        $this->storage->method('claim')->willReturn(self::BATCH_ID);
+        $this->storage->method('tags')->willReturn(self::CACHE_TAGS);
+
+        $this->purgeCacheModel->expects($this->once())
+            ->method('sendPurgeRequest')
+            ->with(self::CACHE_TAGS)
             ->willReturn(false);
 
-        $this->connection->expects($this->never())->method('delete');
+        $this->storage->expects($this->never())->method('clear');
+        $this->storage->expects($this->once())->method('release')->with(self::BATCH_ID);
 
         $this->loggerInterface->expects($this->once())->method('error');
 
@@ -73,19 +79,23 @@ class EntriesTest extends TestCase
 
     public function testFlushResetsDebounceFlagEvenWhenPurgeRequestThrows()
     {
-        $scopeConfig = $this->createMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
         $scopeConfig->method('isSetFlag')->willReturn(true);
-        $config = new \SamJUK\CacheDebounce\Model\Config($scopeConfig);
+        $config = new CacheDebounceConfig($scopeConfig);
 
-        $this->connection->method('fetchCol')->willReturn(self::CACHE_TAGS);
+        $this->storage->method('claim')->willReturn(self::BATCH_ID);
+        $this->storage->method('tags')->willReturn(self::CACHE_TAGS);
         $this->purgeCacheModel->method('sendPurgeRequest')->willThrowException(new \RuntimeException('varnish down'));
 
         $entries = new CacheDebounceEntries(
             $config,
             $this->purgeCacheModel,
-            $this->resourceConnection,
+            $this->storage,
             $this->loggerInterface
         );
+
+        $this->storage->expects($this->never())->method('clear');
+        $this->storage->expects($this->once())->method('release')->with(self::BATCH_ID);
 
         $this->assertTrue($config->shouldDebouncePurgeRequest());
 
@@ -99,19 +109,17 @@ class EntriesTest extends TestCase
         $this->assertTrue($config->shouldDebouncePurgeRequest());
     }
 
-    public function testAddWithEmptyTagsDoesNotTouchConnection()
+    public function testAddDelegatesToStorage()
     {
-        $this->connection->expects($this->never())->method('insertArray');
-
-        $this->cacheDebounceEntries->add([]);
-    }
-
-    public function testAddWithTagsInsertsThem()
-    {
-        $this->connection->expects($this->once())
-            ->method('insertArray')
-            ->with($this->anything(), ['tag'], self::CACHE_TAGS);
+        $this->storage->expects($this->once())->method('add')->with(self::CACHE_TAGS);
 
         $this->cacheDebounceEntries->add(self::CACHE_TAGS);
+    }
+
+    public function testAddWithEmptyTagsStillDelegatesToStorage()
+    {
+        $this->storage->expects($this->once())->method('add')->with([]);
+
+        $this->cacheDebounceEntries->add([]);
     }
 }

--- a/Test/Unit/Model/EntriesTest.php
+++ b/Test/Unit/Model/EntriesTest.php
@@ -4,6 +4,7 @@ namespace SamJUK\CacheDebounce\Test\Unit\Model;
 
 use Magento\CacheInvalidate\Model\PurgeCache;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\FlagManager;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use SamJUK\CacheDebounce\Model\Config as CacheDebounceConfig;
@@ -19,6 +20,7 @@ class EntriesTest extends TestCase
     private $purgeCacheModel;
     private $storage;
     private $loggerInterface;
+    private $flagManager;
     private $cacheDebounceEntries;
 
     protected function setUp(): void
@@ -27,11 +29,13 @@ class EntriesTest extends TestCase
         $this->storage = $this->createMock(QueueStorageInterface::class);
         $this->purgeCacheModel = $this->createMock(PurgeCache::class);
         $this->loggerInterface = $this->createMock(LoggerInterface::class);
+        $this->flagManager = $this->createMock(FlagManager::class);
         $this->cacheDebounceEntries = new CacheDebounceEntries(
             $this->cacheDebounceConfig,
             $this->purgeCacheModel,
             $this->storage,
-            $this->loggerInterface
+            $this->loggerInterface,
+            $this->flagManager
         );
     }
 
@@ -55,6 +59,46 @@ class EntriesTest extends TestCase
             ->willReturn(true);
 
         $this->storage->expects($this->once())->method('clear')->with(self::BATCH_ID);
+
+        $this->cacheDebounceEntries->flush();
+    }
+
+    public function testFlushResumesAnAlreadyClaimedBatchInsteadOfClaimingNew()
+    {
+        $this->storage->method('activeBatch')->willReturn(self::BATCH_ID);
+        $this->storage->method('tags')->with(self::BATCH_ID)->willReturn(self::CACHE_TAGS);
+        $this->storage->expects($this->never())->method('claim');
+
+        $this->purgeCacheModel->method('sendPurgeRequest')->willReturn(true);
+
+        $this->storage->expects($this->once())->method('clear')->with(self::BATCH_ID);
+
+        $this->cacheDebounceEntries->flush();
+    }
+
+    public function testFlushWritesLastFlushFlagsOnSuccess()
+    {
+        $this->storage->method('claim')->willReturn(self::BATCH_ID);
+        $this->storage->method('tags')->willReturn(self::CACHE_TAGS);
+        $this->purgeCacheModel->method('sendPurgeRequest')->willReturn(true);
+
+        $this->flagManager->expects($this->exactly(2))->method('saveFlag')->with(
+            $this->logicalOr(
+                CacheDebounceEntries::FLAG_LAST_FLUSH_AT,
+                CacheDebounceEntries::FLAG_LAST_FLUSH_DURATION
+            )
+        );
+
+        $this->cacheDebounceEntries->flush();
+    }
+
+    public function testFlushDoesNotWriteLastFlushFlagsWhenPurgeRequestFails()
+    {
+        $this->storage->method('claim')->willReturn(self::BATCH_ID);
+        $this->storage->method('tags')->willReturn(self::CACHE_TAGS);
+        $this->purgeCacheModel->method('sendPurgeRequest')->willReturn(false);
+
+        $this->flagManager->expects($this->never())->method('saveFlag');
 
         $this->cacheDebounceEntries->flush();
     }
@@ -91,7 +135,8 @@ class EntriesTest extends TestCase
             $config,
             $this->purgeCacheModel,
             $this->storage,
-            $this->loggerInterface
+            $this->loggerInterface,
+            $this->flagManager
         );
 
         $this->storage->expects($this->never())->method('clear');

--- a/Test/Unit/Model/LagDetectorTest.php
+++ b/Test/Unit/Model/LagDetectorTest.php
@@ -1,0 +1,116 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Unit\Model;
+
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\FlagManager;
+use Magento\Framework\Notification\NotifierInterface;
+use Psr\Log\LoggerInterface;
+use SamJUK\CacheDebounce\Model\Config;
+use SamJUK\CacheDebounce\Model\LagDetector;
+
+class LagDetectorTest extends TestCase
+{
+    private $config;
+    private $flagManager;
+    private $notifier;
+    private $logger;
+    private $detector;
+
+    /** @var mixed persisted flag value, backing the FlagManager mock like a real store would */
+    private $flagState;
+
+    protected function setUp(): void
+    {
+        $this->flagState = null;
+
+        $this->config = $this->createMock(Config::class);
+        $this->config->method('getStaggerLagRatioThreshold')->willReturn(1.0);
+        $this->config->method('getStaggerLagAlertAfterRuns')->willReturn(3);
+
+        $this->flagManager = $this->createMock(FlagManager::class);
+        $this->flagManager->method('getFlagData')->willReturnCallback(function () {
+            return $this->flagState;
+        });
+        $this->flagManager->method('saveFlag')->willReturnCallback(function ($code, $value) {
+            $this->flagState = $value;
+            return true;
+        });
+        $this->flagManager->method('deleteFlag')->willReturnCallback(function () {
+            $this->flagState = null;
+            return true;
+        });
+
+        $this->notifier = $this->createMock(NotifierInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->detector = new LagDetector($this->config, $this->flagManager, $this->notifier, $this->logger);
+    }
+
+    /**
+     * @param array<array{0: int, 1: int}> $samples pairs of [claimed, arrivedDuring]
+     */
+    private function runSequence(array $samples): void
+    {
+        foreach ($samples as [$claimed, $arrivedDuring]) {
+            $this->detector->recordSample($claimed, $arrivedDuring);
+        }
+    }
+
+    public function testNonLaggingSampleDeletesTheCounterAndNeverNotifies()
+    {
+        $this->notifier->expects($this->never())->method('addMajor');
+
+        $this->runSequence([[10, 5]]);
+
+        $this->assertNull($this->flagState);
+    }
+
+    public function testRatioAtExactlyTheThresholdCountsAsLagging()
+    {
+        $this->runSequence([[10, 10]]);
+
+        $this->assertSame(1, $this->flagState);
+    }
+
+    public function testZeroClaimedNeverCountsAsLaggingRegardlessOfArrivals()
+    {
+        $this->notifier->expects($this->never())->method('addMajor');
+
+        $this->runSequence([[0, 5]]);
+
+        $this->assertNull($this->flagState);
+    }
+
+    public function testConsecutiveLaggingRunsAccumulateAndNotifyOnlyOnReachingTheThreshold()
+    {
+        $this->notifier->expects($this->once())->method('addMajor');
+        $this->logger->expects($this->once())->method('warning');
+
+        // lag_alert_after_runs = 3: first two lagging runs stay silent.
+        $this->runSequence([[10, 20], [10, 20], [10, 20]]);
+
+        $this->assertSame(3, $this->flagState);
+    }
+
+    public function testANonLaggingRunResetsTheCounterSoTheNextLagStartsFromOne()
+    {
+        $this->notifier->expects($this->never())->method('addMajor');
+
+        $this->runSequence([[10, 20], [10, 20], [10, 5], [10, 20]]);
+
+        $this->assertSame(1, $this->flagState);
+    }
+
+    public function testSustainedLagReNotifiesEveryAlertAfterRunsWithoutResetting()
+    {
+        $this->notifier->expects($this->exactly(2))->method('addMajor');
+
+        $this->runSequence([
+            [10, 20], [10, 20], [10, 20], // 3rd run: 1st notification
+            [10, 20], [10, 20], [10, 20], // 6th run: 2nd notification
+        ]);
+
+        $this->assertSame(6, $this->flagState);
+    }
+}

--- a/Test/Unit/Model/StaggeredFlushTest.php
+++ b/Test/Unit/Model/StaggeredFlushTest.php
@@ -1,0 +1,200 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Unit\Model;
+
+use PHPUnit\Framework\TestCase;
+use Magento\CacheInvalidate\Model\PurgeCache;
+use Magento\Framework\FlagManager;
+use Magento\Framework\Lock\LockManagerInterface;
+use Psr\Log\LoggerInterface;
+use SamJUK\CacheDebounce\Model\Config;
+use SamJUK\CacheDebounce\Model\Entries;
+use SamJUK\CacheDebounce\Model\LagDetector;
+use SamJUK\CacheDebounce\Model\StaggeredFlush;
+use SamJUK\CacheDebounce\Model\Storage\QueueStorageInterface;
+
+class StaggeredFlushTest extends TestCase
+{
+    private const BATCH_ID = 'batch-123';
+
+    private $config;
+    private $storage;
+    private $purgeCache;
+    private $lockManager;
+    private $lagDetector;
+    private $flagManager;
+    private $entries;
+    private $logger;
+
+    protected function setUp(): void
+    {
+        $this->config = $this->createMock(Config::class);
+        $this->config->method('isStaggerEnabled')->willReturn(true);
+        $this->config->method('getStaggerBatchSize')->willReturn(50);
+        $this->config->method('getStaggerIntervalMs')->willReturn(0);
+        $this->config->method('getStaggerMaxRuntimeSeconds')->willReturn(999);
+
+        $this->storage = $this->createMock(QueueStorageInterface::class);
+        $this->storage->method('activeBatch')->willReturn('');
+
+        $this->purgeCache = $this->createMock(PurgeCache::class);
+        $this->purgeCache->method('sendPurgeRequest')->willReturn(true);
+
+        $this->lockManager = $this->createMock(LockManagerInterface::class);
+        $this->lockManager->method('lock')->willReturn(true);
+
+        $this->lagDetector = $this->createMock(LagDetector::class);
+        $this->flagManager = $this->createMock(FlagManager::class);
+        $this->entries = $this->createMock(Entries::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+    }
+
+    private function staggeredFlush(): StaggeredFlush
+    {
+        return new StaggeredFlush(
+            $this->config,
+            $this->storage,
+            $this->purgeCache,
+            $this->lockManager,
+            $this->lagDetector,
+            $this->flagManager,
+            $this->entries,
+            $this->logger
+        );
+    }
+
+    public function testFallsBackToASingleShotFlushWhenStaggerIsDisabled()
+    {
+        $this->config = $this->createMock(Config::class);
+        $this->config->method('isStaggerEnabled')->willReturn(false);
+
+        $this->entries->expects($this->once())->method('flush');
+        $this->lockManager->expects($this->never())->method('lock');
+
+        $this->staggeredFlush()->execute();
+    }
+
+    public function testFailedLockAcquisitionExitsWithoutCallingClaim()
+    {
+        $this->lockManager = $this->createMock(LockManagerInterface::class);
+        $this->lockManager->method('lock')->willReturn(false);
+
+        $this->storage->expects($this->never())->method('claim');
+        $this->lockManager->expects($this->never())->method('unlock');
+
+        $this->staggeredFlush()->execute();
+    }
+
+    public function testNothingPendingUnlocksWithoutPurging()
+    {
+        $this->storage->method('claim')->willReturn('');
+
+        $this->purgeCache->expects($this->never())->method('sendPurgeRequest');
+        $this->lockManager->expects($this->once())->method('unlock');
+
+        $this->staggeredFlush()->execute();
+    }
+
+    public function testResumesAnAlreadyClaimedActiveBatchInsteadOfReclaiming()
+    {
+        $this->storage = $this->createMock(QueueStorageInterface::class);
+        $this->storage->method('activeBatch')->willReturn(self::BATCH_ID);
+        $this->storage->method('tags')->with(self::BATCH_ID)->willReturn(['cat_c_1']);
+        $this->storage->expects($this->never())->method('claim');
+        $this->storage->expects($this->once())->method('clear')->with(self::BATCH_ID);
+
+        // A resumed batch's post-drain pendingCount() can include tags that
+        // arrived before this run started, so it's not sampled for lag.
+        $this->lagDetector->expects($this->never())->method('recordSample');
+
+        $this->staggeredFlush()->execute();
+    }
+
+    public function testChunksTagsAccordingToBatchSize()
+    {
+        $this->config = $this->createMock(Config::class);
+        $this->config->method('isStaggerEnabled')->willReturn(true);
+        $this->config->method('getStaggerBatchSize')->willReturn(2);
+        $this->config->method('getStaggerIntervalMs')->willReturn(0);
+        $this->config->method('getStaggerMaxRuntimeSeconds')->willReturn(999);
+        $this->storage->method('claim')->willReturn(self::BATCH_ID);
+        $this->storage->method('tags')->willReturn(['a', 'b', 'c', 'd', 'e']);
+
+        $chunks = [];
+        $this->purgeCache->expects($this->exactly(3))
+            ->method('sendPurgeRequest')
+            ->willReturnCallback(function ($chunk) use (&$chunks) {
+                $chunks[] = $chunk;
+                return true;
+            });
+
+        $this->staggeredFlush()->execute();
+
+        $this->assertSame([['a', 'b'], ['c', 'd'], ['e']], $chunks);
+    }
+
+    public function testStopsAndDoesNotClearOnceTheRuntimeBudgetIsExceededMidRun()
+    {
+        // Multiple chunks, so the budget check (which only applies from the
+        // second chunk onward) has a chance to actually stop the run.
+        $this->config = $this->createMock(Config::class);
+        $this->config->method('isStaggerEnabled')->willReturn(true);
+        $this->config->method('getStaggerBatchSize')->willReturn(1);
+        $this->config->method('getStaggerIntervalMs')->willReturn(0);
+        $this->config->method('getStaggerMaxRuntimeSeconds')->willReturn(0);
+        $this->storage->method('claim')->willReturn(self::BATCH_ID);
+        $this->storage->method('tags')->willReturn(['cat_c_1', 'cat_c_2']);
+
+        $this->purgeCache->expects($this->once())->method('sendPurgeRequest')->willReturn(true);
+        $this->storage->expects($this->never())->method('clear');
+        $this->lagDetector->expects($this->never())->method('recordSample');
+        $this->lockManager->expects($this->once())->method('unlock');
+
+        $this->staggeredFlush()->execute();
+    }
+
+    public function testAlwaysSendsTheFirstChunkEvenWithAnExhaustedRuntimeBudget()
+    {
+        // A misconfigured (e.g. zero) budget must never block *every*
+        // chunk — otherwise the batch can never drain, ever, on any run.
+        $this->config = $this->createMock(Config::class);
+        $this->config->method('isStaggerEnabled')->willReturn(true);
+        $this->config->method('getStaggerBatchSize')->willReturn(50);
+        $this->config->method('getStaggerIntervalMs')->willReturn(0);
+        $this->config->method('getStaggerMaxRuntimeSeconds')->willReturn(0);
+        $this->storage->method('claim')->willReturn(self::BATCH_ID);
+        $this->storage->method('tags')->willReturn(['cat_c_1']);
+        $this->storage->method('pendingCount')->willReturn(0);
+
+        $this->purgeCache->expects($this->once())->method('sendPurgeRequest')->with(['cat_c_1'])->willReturn(true);
+        $this->storage->expects($this->once())->method('clear')->with(self::BATCH_ID);
+
+        $this->staggeredFlush()->execute();
+    }
+
+    public function testAFailedPurgeChunkLeavesTheBatchClaimedAndStops()
+    {
+        $this->storage->method('claim')->willReturn(self::BATCH_ID);
+        $this->storage->method('tags')->willReturn(['cat_c_1', 'cat_c_2']);
+        $this->purgeCache = $this->createMock(PurgeCache::class);
+        $this->purgeCache->method('sendPurgeRequest')->willReturn(false);
+
+        $this->storage->expects($this->never())->method('clear');
+        $this->lagDetector->expects($this->never())->method('recordSample');
+
+        $this->staggeredFlush()->execute();
+    }
+
+    public function testFullyDrainedBatchIsClearedAndRecordedForLagDetection()
+    {
+        $this->storage->method('claim')->willReturn(self::BATCH_ID);
+        $this->storage->method('tags')->willReturn(['cat_c_1', 'cat_c_2']);
+        $this->storage->method('pendingCount')->willReturn(1);
+
+        $this->storage->expects($this->once())->method('clear')->with(self::BATCH_ID);
+        $this->lagDetector->expects($this->once())->method('recordSample')->with(2, 1);
+        $this->flagManager->expects($this->exactly(2))->method('saveFlag');
+
+        $this->staggeredFlush()->execute();
+    }
+}

--- a/Test/Unit/Model/Storage/DatabaseTest.php
+++ b/Test/Unit/Model/Storage/DatabaseTest.php
@@ -162,4 +162,65 @@ class DatabaseTest extends TestCase
 
         $this->storage->release('batch-123');
     }
+
+    public function testPendingCountCountsOnlyUnclaimedRows()
+    {
+        $select = $this->createMock(\Magento\Framework\DB\Select::class);
+        $select->method('from')->with(self::TABLE_NAME, ['count' => 'COUNT(*)'])->willReturn($select);
+        $select->method('where')->with('batch_id = ?', '')->willReturn($select);
+        $this->connection->method('select')->willReturn($select);
+        $this->connection->method('fetchOne')->with($select)->willReturn('5');
+
+        $this->assertSame(5, $this->storage->pendingCount());
+    }
+
+    public function testActiveBatchReturnsEmptyStringWhenNothingClaimed()
+    {
+        $select = $this->createMock(\Magento\Framework\DB\Select::class);
+        $select->method('from')->willReturn($select);
+        $select->method('where')->with('batch_id != ?', '')->willReturn($select);
+        $select->method('limit')->with(1)->willReturn($select);
+        $this->connection->method('select')->willReturn($select);
+        $this->connection->method('fetchOne')->willReturn(false);
+
+        $this->assertSame('', $this->storage->activeBatch());
+    }
+
+    public function testActiveBatchReturnsIdOfAlreadyClaimedBatch()
+    {
+        $select = $this->createMock(\Magento\Framework\DB\Select::class);
+        $select->method('from')->willReturn($select);
+        $select->method('where')->willReturn($select);
+        $select->method('limit')->willReturn($select);
+        $this->connection->method('select')->willReturn($select);
+        $this->connection->method('fetchOne')->willReturn('batch-123');
+
+        $this->assertSame('batch-123', $this->storage->activeBatch());
+    }
+
+    public function testOldestPendingAgeSecondsReturnsNullWhenNothingPending()
+    {
+        // Aggregate query returns one row of SQL NULL, which PDO surfaces as null.
+        $select = $this->createMock(\Magento\Framework\DB\Select::class);
+        $select->method('from')->willReturn($select);
+        $select->method('where')->willReturn($select);
+        $this->connection->method('select')->willReturn($select);
+        $this->connection->method('fetchOne')->willReturn(null);
+
+        $this->assertNull($this->storage->oldestPendingAgeSeconds());
+    }
+
+    public function testOldestPendingAgeSecondsReturnsAgeComputedBySql()
+    {
+        $select = $this->createMock(\Magento\Framework\DB\Select::class);
+        $select->method('from')->with(
+            self::TABLE_NAME,
+            ['age' => 'TIMESTAMPDIFF(SECOND, MIN(created_at), NOW())']
+        )->willReturn($select);
+        $select->method('where')->willReturn($select);
+        $this->connection->method('select')->willReturn($select);
+        $this->connection->method('fetchOne')->willReturn('10');
+
+        $this->assertSame(10, $this->storage->oldestPendingAgeSeconds());
+    }
 }

--- a/Test/Unit/Model/Storage/DatabaseTest.php
+++ b/Test/Unit/Model/Storage/DatabaseTest.php
@@ -1,0 +1,165 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Unit\Model\Storage;
+
+use PHPUnit\Framework\TestCase;
+use SamJUK\CacheDebounce\Model\Storage\Database;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+
+class DatabaseTest extends TestCase
+{
+    private const TABLE_NAME = 'samjuk_cache_debounce';
+
+    private $connection;
+    private $resourceConnection;
+    private $storage;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(AdapterInterface::class);
+        $this->connection->method('quoteInto')->willReturnCallback(
+            fn ($text, $value) => str_replace('?', "'$value'", $text)
+        );
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+        $this->resourceConnection->method('getConnection')->willReturn($this->connection);
+        $this->resourceConnection->method('getTableName')->willReturn(self::TABLE_NAME);
+
+        $this->storage = new Database($this->resourceConnection);
+    }
+
+    private function stubSelect(): void
+    {
+        $select = $this->createMock(\Magento\Framework\DB\Select::class);
+        $select->method('from')->willReturn($select);
+        $select->method('where')->willReturn($select);
+        $this->connection->method('select')->willReturn($select);
+    }
+
+    public function testAddWithEmptyTagsDoesNotTouchConnection()
+    {
+        $this->connection->expects($this->never())->method('insertArray');
+
+        $this->storage->add([]);
+    }
+
+    public function testAddInsertsTagsAsUnclaimedWithInsertIgnore()
+    {
+        $this->stubSelect();
+        $this->connection->method('fetchCol')->willReturn([]);
+
+        $this->connection->expects($this->once())
+            ->method('insertArray')
+            ->with(
+                self::TABLE_NAME,
+                ['batch_id', 'tag'],
+                [['', 'cat_c_1'], ['', 'cat_c_2']],
+                AdapterInterface::INSERT_IGNORE
+            );
+
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+    }
+
+    public function testAddFiltersOutNullAndEmptyTags()
+    {
+        $this->stubSelect();
+        $this->connection->method('fetchCol')->willReturn([]);
+
+        $this->connection->expects($this->once())
+            ->method('insertArray')
+            ->with(
+                self::TABLE_NAME,
+                ['batch_id', 'tag'],
+                [['', 'cat_c_1']],
+                AdapterInterface::INSERT_IGNORE
+            );
+
+        $this->storage->add(['cat_c_1', null, '']);
+    }
+
+    public function testAddSkipsTagsAlreadyPending()
+    {
+        $this->stubSelect();
+        $this->connection->method('fetchCol')->willReturn(['cat_c_1']);
+
+        $this->connection->expects($this->once())
+            ->method('insertArray')
+            ->with(
+                self::TABLE_NAME,
+                ['batch_id', 'tag'],
+                [['', 'cat_c_2']],
+                AdapterInterface::INSERT_IGNORE
+            );
+
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+    }
+
+    public function testAddInsertsNothingWhenEveryTagIsAlreadyPending()
+    {
+        $this->stubSelect();
+        $this->connection->method('fetchCol')->willReturn(['cat_c_1']);
+
+        $this->connection->expects($this->never())->method('insertArray');
+
+        $this->storage->add(['cat_c_1']);
+    }
+
+    public function testClaimReturnsEmptyStringWhenNothingPending()
+    {
+        $this->connection->method('update')->willReturn(0);
+
+        $this->assertSame('', $this->storage->claim());
+    }
+
+    public function testClaimReturnsBatchIdWhenRowsClaimed()
+    {
+        $this->connection->method('update')->willReturn(2);
+
+        $batchId = $this->storage->claim();
+
+        $this->assertNotSame('', $batchId);
+        $this->assertSame(32, strlen($batchId));
+    }
+
+    public function testTagsSelectsScopedToBatchId()
+    {
+        $select = $this->createMock(\Magento\Framework\DB\Select::class);
+        $select->method('from')->willReturn($select);
+        $select->method('where')->with('batch_id = ?', 'batch-123')->willReturn($select);
+        $this->connection->method('select')->willReturn($select);
+        $this->connection->method('fetchCol')->willReturn(['cat_c_1']);
+
+        $this->assertSame(['cat_c_1'], $this->storage->tags('batch-123'));
+    }
+
+    public function testClearDeletesOnlyThatBatch()
+    {
+        $this->connection->expects($this->once())
+            ->method('delete')
+            ->with(self::TABLE_NAME, "batch_id = 'batch-123'");
+
+        $this->storage->clear('batch-123');
+    }
+
+    public function testReleaseReQueuesBatchTagsAsUnclaimedThenClearsTheBatch()
+    {
+        $this->stubSelect();
+        // First call is tags($batchId) reading the claimed batch; second is
+        // add()'s own dedup check against currently-pending tags.
+        $this->connection->method('fetchCol')->willReturnOnConsecutiveCalls(['cat_c_1', 'cat_c_2'], []);
+
+        $this->connection->expects($this->once())
+            ->method('insertArray')
+            ->with(
+                self::TABLE_NAME,
+                ['batch_id', 'tag'],
+                [['', 'cat_c_1'], ['', 'cat_c_2']],
+                AdapterInterface::INSERT_IGNORE
+            );
+        $this->connection->expects($this->once())
+            ->method('delete')
+            ->with(self::TABLE_NAME, "batch_id = 'batch-123'");
+
+        $this->storage->release('batch-123');
+    }
+}

--- a/Test/Unit/Model/Storage/PoolTest.php
+++ b/Test/Unit/Model/Storage/PoolTest.php
@@ -87,4 +87,28 @@ class PoolTest extends TestCase
 
         $this->pool()->release('batch-123');
     }
+
+    public function testPendingCountDelegatesToTheResolvedDriver()
+    {
+        $this->scopeConfig->method('getValue')->willReturn('db');
+        $this->database->expects($this->once())->method('pendingCount')->willReturn(5);
+
+        $this->assertSame(5, $this->pool()->pendingCount());
+    }
+
+    public function testActiveBatchDelegatesToTheResolvedDriver()
+    {
+        $this->scopeConfig->method('getValue')->willReturn('redis');
+        $this->redis->expects($this->once())->method('activeBatch')->willReturn('batch-123');
+
+        $this->assertSame('batch-123', $this->pool()->activeBatch());
+    }
+
+    public function testOldestPendingAgeSecondsDelegatesToTheResolvedDriver()
+    {
+        $this->scopeConfig->method('getValue')->willReturn('db');
+        $this->database->expects($this->once())->method('oldestPendingAgeSeconds')->willReturn(42);
+
+        $this->assertSame(42, $this->pool()->oldestPendingAgeSeconds());
+    }
 }

--- a/Test/Unit/Model/Storage/PoolTest.php
+++ b/Test/Unit/Model/Storage/PoolTest.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Unit\Model\Storage;
+
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\ObjectManagerInterface;
+use SamJUK\CacheDebounce\Model\Storage\Database;
+use SamJUK\CacheDebounce\Model\Storage\Pool;
+use SamJUK\CacheDebounce\Model\Storage\Redis;
+
+class PoolTest extends TestCase
+{
+    private const XML_PATH_STORAGE_DRIVER = 'samjuk_cache_debounce_advanced/general/storage_driver';
+    private const CACHE_TAGS = ['cat_c_1', 'cat_c_2'];
+    private const DRIVERS = [
+        'db' => Database::class,
+        'redis' => Redis::class,
+    ];
+
+    private $objectManager;
+    private $scopeConfig;
+    private $database;
+    private $redis;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = $this->createMock(ObjectManagerInterface::class);
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->database = $this->createMock(Database::class);
+        $this->redis = $this->createMock(Redis::class);
+
+        $this->objectManager->method('create')->willReturnMap([
+            [Database::class, [], $this->database],
+            [Redis::class, [], $this->redis],
+        ]);
+    }
+
+    private function pool(): Pool
+    {
+        return new Pool($this->objectManager, $this->scopeConfig, self::DRIVERS);
+    }
+
+    public function testUsesDatabaseDriverByDefault()
+    {
+        $this->scopeConfig->method('getValue')->with(self::XML_PATH_STORAGE_DRIVER)->willReturn(null);
+
+        $this->database->expects($this->once())->method('add')->with(self::CACHE_TAGS);
+
+        $this->pool()->add(self::CACHE_TAGS);
+    }
+
+    public function testUsesDatabaseDriverForAnyValueOtherThanRedis()
+    {
+        $this->scopeConfig->method('getValue')->willReturn('db');
+
+        $this->database->expects($this->once())->method('claim')->willReturn('batch-123');
+
+        $this->pool()->claim();
+    }
+
+    public function testUsesRedisDriverWhenConfiguredAndNeverTouchesDatabase()
+    {
+        $this->scopeConfig->method('getValue')->willReturn('redis');
+
+        $this->database->expects($this->never())->method('add');
+        $this->redis->expects($this->once())->method('add')->with(self::CACHE_TAGS);
+
+        $this->pool()->add(self::CACHE_TAGS);
+    }
+
+    public function testDriverIsOnlyResolvedOnceAcrossMultipleCalls()
+    {
+        $objectManager = $this->createMock(ObjectManagerInterface::class);
+        $objectManager->expects($this->once())->method('create')->with(Redis::class)->willReturn($this->redis);
+        $this->scopeConfig->method('getValue')->willReturn('redis');
+
+        $pool = new Pool($objectManager, $this->scopeConfig, self::DRIVERS);
+        $pool->add(['cat_c_1']);
+        $pool->claim();
+    }
+
+    public function testReleaseDelegatesToTheResolvedDriver()
+    {
+        $this->scopeConfig->method('getValue')->willReturn('db');
+        $this->database->expects($this->once())->method('release')->with('batch-123');
+
+        $this->pool()->release('batch-123');
+    }
+}

--- a/Test/Unit/Model/Storage/Redis/ConnectionResolverTest.php
+++ b/Test/Unit/Model/Storage/Redis/ConnectionResolverTest.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Unit\Model\Storage\Redis;
+
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Exception\LocalizedException;
+use SamJUK\CacheDebounce\Model\Storage\Redis\ConnectionResolver;
+
+class ConnectionResolverTest extends TestCase
+{
+    private const DEDICATED_CONFIG = ['host' => '10.0.0.1', 'port' => '6390', 'password' => 'x', 'database' => '2'];
+    private const FALLBACK_CONFIG = ['server' => '10.0.0.2', 'port' => '6379', 'password' => '', 'database' => '0'];
+
+    private $deploymentConfig;
+
+    protected function setUp(): void
+    {
+        $this->deploymentConfig = $this->createMock(DeploymentConfig::class);
+    }
+
+    public function testDedicatedConfigTakesPriorityOverTheSharedFallback()
+    {
+        $this->deploymentConfig->method('get')->willReturnMap([
+            ['cache_debounce/redis', null, self::DEDICATED_CONFIG],
+            ['cache/frontend/page_cache/backend_options', null, self::FALLBACK_CONFIG],
+        ]);
+
+        $this->assertResolvesToClient();
+    }
+
+    public function testFallsBackToThePageCacheBackendWhenDedicatedConfigIsAbsent()
+    {
+        $this->deploymentConfig->method('get')->willReturnMap([
+            ['cache_debounce/redis', null, null],
+            ['cache/frontend/page_cache/backend_options', null, self::FALLBACK_CONFIG],
+        ]);
+
+        $this->assertResolvesToClient();
+    }
+
+    public function testThrowsLocalizedExceptionWhenNeitherConfigIsAvailable()
+    {
+        $this->deploymentConfig->method('get')->willReturn(null);
+
+        $resolver = new ConnectionResolver($this->deploymentConfig);
+
+        $this->expectException(LocalizedException::class);
+
+        $resolver->getClient();
+    }
+
+    public function testDedicatedConfigMissingKeysFallsBackToDefaultsInsteadOfErroring()
+    {
+        $this->deploymentConfig->method('get')->willReturnMap([
+            ['cache_debounce/redis', null, ['host' => '10.0.0.9']],
+            ['cache/frontend/page_cache/backend_options', null, null],
+        ]);
+
+        $this->assertResolvesToClient();
+    }
+
+    private function assertResolvesToClient(): void
+    {
+        $resolver = new ConnectionResolver($this->deploymentConfig);
+
+        $this->assertInstanceOf(\Credis_Client::class, $resolver->getClient());
+    }
+}

--- a/Test/Unit/Model/Storage/RedisTest.php
+++ b/Test/Unit/Model/Storage/RedisTest.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+namespace SamJUK\CacheDebounce\Test\Unit\Model\Storage;
+
+use PHPUnit\Framework\TestCase;
+use SamJUK\CacheDebounce\Model\Storage\Redis;
+use SamJUK\CacheDebounce\Model\Storage\Redis\ConnectionResolver;
+
+class RedisTest extends TestCase
+{
+    private const KEY_LIVE = 'samjuk_cache_debounce:queue:live';
+    private const KEY_BATCH_PREFIX = 'samjuk_cache_debounce:queue:batch:';
+
+    private $client;
+    private $connectionResolver;
+    private $storage;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->getMockBuilder(\Credis_Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['sAdd', 'rename', 'sMembers', 'del', 'sUnionStore'])
+            ->getMock();
+        $this->connectionResolver = $this->createMock(ConnectionResolver::class);
+        $this->connectionResolver->method('getClient')->willReturn($this->client);
+
+        $this->storage = new Redis($this->connectionResolver);
+    }
+
+    public function testAddWithEmptyTagsDoesNotTouchConnection()
+    {
+        $this->client->expects($this->never())->method('sAdd');
+
+        $this->storage->add([]);
+    }
+
+    public function testAddSaddsTagsIntoTheLiveSet()
+    {
+        $this->client->expects($this->once())
+            ->method('sAdd')
+            ->with(self::KEY_LIVE, 'cat_c_1', 'cat_c_2');
+
+        $this->storage->add(['cat_c_1', 'cat_c_2']);
+    }
+
+    public function testClaimReturnsEmptyStringWhenLiveKeyDoesNotExist()
+    {
+        $this->client->method('rename')->willThrowException(new \CredisException('ERR no such key'));
+
+        $this->assertSame('', $this->storage->claim());
+    }
+
+    public function testClaimDoesNotSwallowOtherRedisErrors()
+    {
+        $this->client->method('rename')->willThrowException(new \CredisException('ERR something else'));
+
+        $this->expectException(\CredisException::class);
+        $this->expectExceptionMessage('ERR something else');
+
+        $this->storage->claim();
+    }
+
+    public function testClaimRenamesLiveKeyToABatchKeyAndReturnsItsId()
+    {
+        $this->client->expects($this->once())
+            ->method('rename')
+            ->with(self::KEY_LIVE, $this->callback(function (string $key) {
+                return strpos($key, self::KEY_BATCH_PREFIX) === 0
+                    && strlen($key) === strlen(self::KEY_BATCH_PREFIX) + 32;
+            }));
+
+        $batchId = $this->storage->claim();
+
+        $this->assertNotSame('', $batchId);
+        $this->assertSame(32, strlen($batchId));
+    }
+
+    public function testTagsReadsFromTheBatchKey()
+    {
+        $this->client->expects($this->once())
+            ->method('sMembers')
+            ->with(self::KEY_BATCH_PREFIX . 'batch-123')
+            ->willReturn(['cat_c_1']);
+
+        $this->assertSame(['cat_c_1'], $this->storage->tags('batch-123'));
+    }
+
+    public function testClearDeletesOnlyTheBatchKey()
+    {
+        $this->client->expects($this->once())
+            ->method('del')
+            ->with(self::KEY_BATCH_PREFIX . 'batch-123');
+
+        $this->storage->clear('batch-123');
+    }
+
+    public function testReleaseMergesBatchSetBackIntoLiveSetThenDeletesTheBatch()
+    {
+        $this->client->expects($this->once())
+            ->method('sUnionStore')
+            ->with(self::KEY_LIVE, self::KEY_LIVE, self::KEY_BATCH_PREFIX . 'batch-123');
+        $this->client->expects($this->once())
+            ->method('del')
+            ->with(self::KEY_BATCH_PREFIX . 'batch-123');
+
+        $this->storage->release('batch-123');
+    }
+}

--- a/Test/Unit/Model/Storage/RedisTest.php
+++ b/Test/Unit/Model/Storage/RedisTest.php
@@ -10,6 +10,7 @@ class RedisTest extends TestCase
 {
     private const KEY_LIVE = 'samjuk_cache_debounce:queue:live';
     private const KEY_BATCH_PREFIX = 'samjuk_cache_debounce:queue:batch:';
+    private const KEY_ACTIVE_BATCH = 'samjuk_cache_debounce:queue:active_batch_id';
 
     private $client;
     private $connectionResolver;
@@ -19,7 +20,7 @@ class RedisTest extends TestCase
     {
         $this->client = $this->getMockBuilder(\Credis_Client::class)
             ->disableOriginalConstructor()
-            ->addMethods(['sAdd', 'rename', 'sMembers', 'del', 'sUnionStore'])
+            ->addMethods(['sAdd', 'rename', 'sMembers', 'del', 'sUnionStore', 'sCard', 'set', 'get'])
             ->getMock();
         $this->connectionResolver = $this->createMock(ConnectionResolver::class);
         $this->connectionResolver->method('getClient')->willReturn($this->client);
@@ -75,6 +76,23 @@ class RedisTest extends TestCase
         $this->assertSame(32, strlen($batchId));
     }
 
+    public function testClaimRecordsTheActiveBatchMarker()
+    {
+        $this->client->expects($this->once())
+            ->method('set')
+            ->with(self::KEY_ACTIVE_BATCH, $this->isType('string'));
+
+        $this->storage->claim();
+    }
+
+    public function testClaimDoesNotSetTheActiveBatchMarkerWhenNothingWasPending()
+    {
+        $this->client->method('rename')->willThrowException(new \CredisException('ERR no such key'));
+        $this->client->expects($this->never())->method('set');
+
+        $this->storage->claim();
+    }
+
     public function testTagsReadsFromTheBatchKey()
     {
         $this->client->expects($this->once())
@@ -85,24 +103,66 @@ class RedisTest extends TestCase
         $this->assertSame(['cat_c_1'], $this->storage->tags('batch-123'));
     }
 
-    public function testClearDeletesOnlyTheBatchKey()
+    public function testClearDeletesTheBatchKeyAndTheActiveBatchMarker()
     {
-        $this->client->expects($this->once())
+        $deletedKeys = [];
+        $this->client->expects($this->exactly(2))
             ->method('del')
-            ->with(self::KEY_BATCH_PREFIX . 'batch-123');
+            ->willReturnCallback(function (string $key) use (&$deletedKeys) {
+                $deletedKeys[] = $key;
+                return true;
+            });
 
         $this->storage->clear('batch-123');
+
+        $this->assertSame([self::KEY_BATCH_PREFIX . 'batch-123', self::KEY_ACTIVE_BATCH], $deletedKeys);
     }
 
-    public function testReleaseMergesBatchSetBackIntoLiveSetThenDeletesTheBatch()
+    public function testReleaseMergesBatchSetBackIntoLiveSetThenDeletesTheBatchAndMarker()
     {
         $this->client->expects($this->once())
             ->method('sUnionStore')
             ->with(self::KEY_LIVE, self::KEY_LIVE, self::KEY_BATCH_PREFIX . 'batch-123');
-        $this->client->expects($this->once())
+
+        $deletedKeys = [];
+        $this->client->expects($this->exactly(2))
             ->method('del')
-            ->with(self::KEY_BATCH_PREFIX . 'batch-123');
+            ->willReturnCallback(function (string $key) use (&$deletedKeys) {
+                $deletedKeys[] = $key;
+                return true;
+            });
 
         $this->storage->release('batch-123');
+
+        $this->assertSame([self::KEY_BATCH_PREFIX . 'batch-123', self::KEY_ACTIVE_BATCH], $deletedKeys);
+    }
+
+    public function testPendingCountReadsCardinalityOfTheLiveSet()
+    {
+        $this->client->expects($this->once())
+            ->method('sCard')
+            ->with(self::KEY_LIVE)
+            ->willReturn(3);
+
+        $this->assertSame(3, $this->storage->pendingCount());
+    }
+
+    public function testActiveBatchReturnsEmptyStringWhenNoBatchIsClaimed()
+    {
+        $this->client->method('get')->with(self::KEY_ACTIVE_BATCH)->willReturn(false);
+
+        $this->assertSame('', $this->storage->activeBatch());
+    }
+
+    public function testActiveBatchReturnsIdOfAlreadyClaimedBatch()
+    {
+        $this->client->method('get')->with(self::KEY_ACTIVE_BATCH)->willReturn('batch-123');
+
+        $this->assertSame('batch-123', $this->storage->activeBatch());
+    }
+
+    public function testOldestPendingAgeSecondsIsAlwaysNull()
+    {
+        $this->assertNull($this->storage->oldestPendingAgeSeconds());
     }
 }

--- a/etc/adminhtml/acl.xml
+++ b/etc/adminhtml/acl.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_settings">
+                        <resource id="Magento_Config::config">
+                            <resource id="SamJUK_CacheDebounce::system_config" title="Cache Debounce Section" translate="title" sortOrder="10">
+                                <resource id="SamJUK_CacheDebounce::storage_driver" title="Cache Debounce Storage Driver (Advanced)" translate="title" sortOrder="10" />
+                            </resource>
+                        </resource>
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -23,5 +23,20 @@
                 </field>
             </group>
         </section>
+
+        <!-- showInDefault/Website/Store all "0" hides this from Admin UI; config:set still works -->
+        <section id="samjuk_cache_debounce_advanced" translate="label" type="text" sortOrder="20" showInDefault="0" showInWebsite="0" showInStore="0">
+            <label>Cache Debounce (Advanced)</label>
+            <tab>samjuk</tab>
+            <resource>SamJUK_CacheDebounce::storage_driver</resource>
+            <group id="general" translate="label" type="text" sortOrder="10" showInDefault="0" showInWebsite="0" showInStore="0">
+                <label>General</label>
+                <field id="storage_driver" translate="label comment" type="select" sortOrder="10" showInDefault="0" showInWebsite="0" showInStore="0">
+                    <label>Storage Driver</label>
+                    <comment>Do not change unless you know what you are doing. See README.md.</comment>
+                    <source_model>SamJUK\CacheDebounce\Model\Config\Source\StorageDriver</source_model>
+                </field>
+            </group>
+        </section>
     </system>
 </config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -22,6 +22,34 @@
                     <label>Flush Schedule</label>
                 </field>
             </group>
+            <group id="stagger" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Staggered Release</label>
+                <field id="enabled" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Enabled</label>
+                    <comment>Release a claimed batch gradually instead of purging it all at once. Disabled = single-shot flush() (current behavior).</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="batch_size" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Batch Size</label>
+                    <comment>Tags per purge chunk.</comment>
+                </field>
+                <field id="interval_ms" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Interval (ms)</label>
+                    <comment>Pause between chunks.</comment>
+                </field>
+                <field id="max_runtime_seconds" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Max Runtime (seconds)</label>
+                    <comment>Safety budget per cron/CLI invocation — must comfortably clear before the Flush Schedule interval elapses again.</comment>
+                </field>
+                <field id="lag_ratio_threshold" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Lag Ratio Threshold</label>
+                    <comment>A run counts as "lagging" if tags arriving during the drain are &gt;= this ratio of tags just drained.</comment>
+                </field>
+                <field id="lag_alert_after_runs" translate="label comment" type="text" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Lag Alert After Runs</label>
+                    <comment>Consecutive lagging runs before an admin notification is raised.</comment>
+                </field>
+            </group>
         </section>
 
         <!-- showInDefault/Website/Store all "0" hides this from Admin UI; config:set still works -->

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -9,5 +9,10 @@
                 <flush_schedule>*/15 * * * *</flush_schedule>
             </cron>
         </samjuk_cache_debounce>
+        <samjuk_cache_debounce_advanced>
+            <general>
+                <storage_driver>db</storage_driver>
+            </general>
+        </samjuk_cache_debounce_advanced>
     </default>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,6 +8,14 @@
             <cron>
                 <flush_schedule>*/15 * * * *</flush_schedule>
             </cron>
+            <stagger>
+                <enabled>0</enabled>
+                <batch_size>50</batch_size>
+                <interval_ms>1000</interval_ms>
+                <max_runtime_seconds>240</max_runtime_seconds>
+                <lag_ratio_threshold>1</lag_ratio_threshold>
+                <lag_alert_after_runs>3</lag_alert_after_runs>
+            </stagger>
         </samjuk_cache_debounce>
         <samjuk_cache_debounce_advanced>
             <general>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
     <table name="samjuk_cache_debounce" resource="default" engine="innodb">
+        <!-- No PK yet: existing installs may have dirty rows; ClearQueueTable cleans them before a follow-up release adds it -->
         <column xsi:type="varchar" name="tag" nullable="true" length="255" comment="Tag"/>
+        <column xsi:type="varchar" name="batch_id" nullable="false" length="32" default="" comment="Batch id. Empty string = unclaimed/pending"/>
+        <column xsi:type="timestamp" name="created_at" nullable="false" default="CURRENT_TIMESTAMP" comment="When this tag was first queued"/>
     </table>
 </schema>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -1,0 +1,9 @@
+{
+    "samjuk_cache_debounce": {
+        "column": {
+            "batch_id": true,
+            "tag": true,
+            "created_at": true
+        }
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -19,6 +19,7 @@
         <arguments>
             <argument name="commands" xsi:type="array">
                 <item name="samjuk_cache_debounce_flush" xsi:type="object">SamJUK\CacheDebounce\Console\Command\Flush</item>
+                <item name="samjuk_cache_debounce_status" xsi:type="object">SamJUK\CacheDebounce\Console\Command\Status</item>
             </argument>
         </arguments>
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <preference for="SamJUK\CacheDebounce\Model\Storage\QueueStorageInterface" type="SamJUK\CacheDebounce\Model\Storage\Database" />
+    <preference for="SamJUK\CacheDebounce\Model\Storage\QueueStorageInterface" type="SamJUK\CacheDebounce\Model\Storage\Pool" />
+
+    <type name="SamJUK\CacheDebounce\Model\Storage\Pool">
+        <arguments>
+            <argument name="drivers" xsi:type="array">
+                <item name="db" xsi:type="string">SamJUK\CacheDebounce\Model\Storage\Database</item>
+                <item name="redis" xsi:type="string">SamJUK\CacheDebounce\Model\Storage\Redis</item>
+            </argument>
+        </arguments>
+    </type>
 
     <type name="Magento\CacheInvalidate\Model\PurgeCache">
         <plugin name="samjuk_cachedebounce_purge_cache" type="SamJUK\CacheDebounce\Plugin\PurgeCache" />

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="SamJUK\CacheDebounce\Model\Storage\QueueStorageInterface" type="SamJUK\CacheDebounce\Model\Storage\Database" />
+
     <type name="Magento\CacheInvalidate\Model\PurgeCache">
         <plugin name="samjuk_cachedebounce_purge_cache" type="SamJUK\CacheDebounce\Plugin\PurgeCache" />
     </type>


### PR DESCRIPTION
## Summary
- Stacked on #11 — extends `QueueStorageInterface` with `pendingCount()`, `activeBatch()`, `oldestPendingAgeSeconds()` (Redis returns null for the last one — Sets have no per-member insertion time).
- Adds `StaggeredFlush`: releases a claimed batch in `batch_size`-chunked purge requests paced by `interval_ms`, within a `max_runtime_seconds` budget, guarded by `LockManagerInterface` so only one release runs at a time. Disabled by default (`stagger/enabled = 0`) — falls straight through to the existing single-shot `flush()`, no behavior change for current installs. Both the cron job and `samjuk:cache-debounce:flush` route through it now.
- An interrupted run (deploy/OOM/timeout) leaves its batch claimed, not cleared; the next invocation resumes it by re-purging the full tag list (idempotent BAN, no persisted chunk cursor).
- Adds `LagDetector`: compares tags arriving during a drain against tags just drained, tracks a consecutive-lagging-runs counter via `FlagManager`, and raises an admin bell-icon notification every `lag_alert_after_runs` runs for as long as the lag persists.
- Adds `bin/magento samjuk:cache-debounce:status` for pending count, active batch, last flush, and lagging-run visibility.

Implements [docs/specs/003-staggered-purge-release.md](../blob/master/docs/specs/003-staggered-purge-release.md).

## Test plan
- [ ] `vendor/bin/phpunit Test/Unit` — chunking, runtime-budget cutoff, lock contention, batch resumption, lag-counter/notification cadence
- [ ] `bin/magento setup:di:compile`
- [ ] Integration: simulated mid-loop crash resumes and drains on the next run; two concurrent invocations against a real lock backend only let one through
- [ ] Manual: enable `stagger`, queue >`batch_size` tags, confirm Varnish purges arrive in paced chunks and `samjuk:cache-debounce:status` reflects state throughout