### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest tagged release is supported with security fixes.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Instead, report it privately via
+[GitHub Security Advisories](https://github.com/SamJUK/m2-module-cache-debounce/security/advisories/new).
+
+You should get a response within a few days. Once confirmed, a fix will be
+released and the advisory published with credit (unless you prefer to stay
+anonymous).


### PR DESCRIPTION
Adds a SECURITY.md documenting the private vulnerability reporting process via GitHub Security Advisories.